### PR TITLE
Add GTK desktop UI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,50 @@ PATH
   remote: .
   specs:
     rbshard (0.1.0)
+      gtk3 (>= 4.0)
       twofish (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    atk (4.3.0)
+      glib2 (= 4.3.0)
+    cairo (1.18.4)
+      native-package-installer (>= 1.0.3)
+      pkg-config (>= 1.2.2)
+      red-colors
+    cairo-gobject (4.3.0)
+      cairo (>= 1.16.2)
+      glib2 (= 4.3.0)
+    fiddle (1.1.8)
+    gdk3 (4.3.0)
+      cairo-gobject (= 4.3.0)
+      gdk_pixbuf2 (= 4.3.0)
+      pango (= 4.3.0)
+    gdk_pixbuf2 (4.3.0)
+      gio2 (= 4.3.0)
+    gio2 (4.3.0)
+      fiddle
+      gobject-introspection (= 4.3.0)
+    glib2 (4.3.0)
+      native-package-installer (>= 1.0.3)
+      pkg-config (>= 1.3.5)
+    gobject-introspection (4.3.0)
+      glib2 (= 4.3.0)
+    gtk3 (4.3.0)
+      atk (= 4.3.0)
+      gdk3 (= 4.3.0)
+    json (2.13.2)
+    matrix (0.4.3)
     minitest (5.25.5)
+    native-package-installer (1.1.9)
+    pango (4.3.0)
+      cairo-gobject (= 4.3.0)
+      gobject-introspection (= 4.3.0)
+    pkg-config (1.6.2)
+    red-colors (0.4.0)
+      json
+      matrix
     twofish (1.0.8)
 
 PLATFORMS

--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ Then visit `http://localhost:4567` in your browser to access forms for encoding
 and decoding text using a secret key.
 
 Development is experimental and feedback is welcome.
+
+## Desktop UI
+
+You can also use a simple GTK-based desktop application to run encode and
+decode operations locally:
+
+```
+ruby bin/rbshard_desktop
+```
+
+This opens a window with text areas for input and results along with an entry
+field for your secret key.

--- a/bin/rbshard_desktop
+++ b/bin/rbshard_desktop
@@ -1,0 +1,119 @@
+#!/usr/bin/env ruby
+require 'gtk3'
+require 'base64'
+require_relative '../lib/rbshard'
+
+class RbShardDesktop
+  def initialize
+    @builder = Gtk::Builder.new
+    @builder.add_from_string(UI)
+    @window = @builder['window']
+    @input  = @builder['input_buffer']
+    @output = @builder['output_buffer']
+    @key_entry = @builder['key']
+    @builder['encode_button'].signal_connect('clicked') { encode }
+    @builder['decode_button'].signal_connect('clicked') { decode }
+    @window.signal_connect('destroy') { Gtk.main_quit }
+    @window.show_all
+  end
+
+  def encode
+    data = @input.text
+    key = @key_entry.text
+    result = Base64.strict_encode64(RbShard.encode(data, key))
+    @output.text = result
+  rescue => e
+    @output.text = "Error: #{e.message}"
+  end
+
+  def decode
+    data = @input.text
+    key = @key_entry.text
+    decoded = RbShard.decode(Base64.strict_decode64(data), key)
+    @output.text = decoded
+  rescue => e
+    @output.text = "Error: #{e.message}"
+  end
+
+  UI = <<~UI
+    <interface>
+      <requires lib="gtk+" version="3.0"/>
+      <object class="GtkWindow" id="window">
+        <property name="title">RbShard Desktop</property>
+        <child>
+          <object class="GtkBox" id="main_box">
+            <property name="orientation">vertical</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkLabel" id="input_label">
+                <property name="label">Input</property>
+                <attributes><attribute name="weight" value="bold"/></attributes>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="vexpand">true</property>
+                <child>
+                  <object class="GtkTextView" id="input">
+                    <property name="buffer">input_buffer</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox" id="key_box">
+                <property name="orientation">horizontal</property>
+                <child>
+                  <object class="GtkLabel" id="key_label">
+                    <property name="label">Key:</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="key"/>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox" id="button_box">
+                <property name="orientation">horizontal</property>
+                <property name="spacing">5</property>
+                <child>
+                  <object class="GtkButton" id="encode_button">
+                    <property name="label">Encode</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton" id="decode_button">
+                    <property name="label">Decode</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="output_label">
+                <property name="label">Result</property>
+                <attributes><attribute name="weight" value="bold"/></attributes>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="vexpand">true</property>
+                <child>
+                  <object class="GtkTextView" id="output">
+                    <property name="editable">false</property>
+                    <property name="buffer">output_buffer</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+      <object class="GtkTextBuffer" id="input_buffer"/>
+      <object class="GtkTextBuffer" id="output_buffer"/>
+    </interface>
+  UI
+end
+
+RbShardDesktop.new
+Gtk.main

--- a/rbshard.gemspec
+++ b/rbshard.gemspec
@@ -5,8 +5,9 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Unknown']
   spec.email         = ['unknown@example.com']
   spec.summary       = 'Compression and encryption toolkit'
-  spec.files         = Dir['lib/**/*'] + ['README.md', 'LICENSE']
+  spec.files         = Dir['lib/**/*'] + ['README.md', 'LICENSE', 'bin/rbshard_desktop', 'bin/rbshard_ui']
   spec.require_paths = ['lib']
   spec.add_runtime_dependency 'twofish', '~> 1.0'
+  spec.add_runtime_dependency 'gtk3', '>= 4.0'
   spec.add_development_dependency 'minitest', '~> 5'
 end


### PR DESCRIPTION
## Summary
- add new `rbshard_desktop` executable using GTK3
- document desktop UI usage in README
- include executable and `gtk3` dependency in gemspec

## Testing
- `bundle install`
- `bundle exec ruby -Ilib test/test_rbshard.rb`

------
https://chatgpt.com/codex/tasks/task_e_688b0bde8fb0832f885757fa4c251c2e