### PR TITLE
Expand RbShard with streaming authenticated v3 containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test
+
+      - name: Validate gem specification
+        run: bundle exec ruby -e "spec = Gem::Specification.load('rbshard.gemspec'); abort 'invalid gemspec' unless spec"
+
+      - name: Smoke-test CLI
+        run: bundle exec ruby bin/rbshard version

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,48 +1,66 @@
 name: Ruby Gem
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build:
-    name: Build + Publish
+    name: Build Gem
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test
+
+      - name: Build gem
+        run: gem build rbshard.gemspec
+
+      - name: Smoke-test packaged executable
+        run: |
+          gem install --local ./rbshard-*.gem
+          rbshard version
+
+      - name: Upload gem artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rbshard-gem
+          path: rbshard-*.gem
+
+  publish-rubygems:
+    name: Publish RubyGems
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby 2.6
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
-      with:
-        ruby-version: 2.6.x
+      - uses: actions/checkout@v4
 
-    - name: Publish to GPR
-      run: |
-        mkdir -p $HOME/.gem
-        touch $HOME/.gem/credentials
-        chmod 0600 $HOME/.gem/credentials
-        printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-        gem build *.gemspec
-        gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
-      env:
-        GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
-        OWNER: ${{ github.repository_owner }}
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
 
-    - name: Publish to RubyGems
-      run: |
-        mkdir -p $HOME/.gem
-        touch $HOME/.gem/credentials
-        chmod 0600 $HOME/.gem/credentials
-        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-        gem build *.gemspec
-        gem push *.gem
-      env:
-        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+      - name: Build gem
+        run: gem build rbshard.gemspec
+
+      - name: Publish to RubyGems
+        run: gem push rbshard-*.gem
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Smoke-test packaged executable
         run: |
-          gem install --local ./rbshard-*.gem
+          gem install ./rbshard-*.gem
           rbshard version
 
       - name: Upload gem artifact

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,38 +1,31 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
-name: Ruby
+name: Ruby Compatibility
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
   pull_request:
-    branches: [ "main" ]
+    branches: [main]
 
 permissions:
   contents: read
 
 jobs:
   test:
-
+    name: Ruby ${{ matrix.ruby-version }} compatibility
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4']
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run tests
-      run: bundle exec rake
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: Run test suite
+        run: bundle exec rake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to RbShard will be documented in this file.
+
+The project follows semantic versioning for public releases. Container-format revisions are versioned independently through `RbShard::FORMAT_VERSION`.
+
+## Unreleased
+
+### Added
+
+- Versioned `RBSH` v1 container format with magic bytes and payload length metadata.
+- SHA-256 plaintext integrity verification after decryption.
+- `RbShard.pack`, `RbShard.unpack`, `RbShard.container?`, and `RbShard.inspect_rbs` helpers.
+- Optional rejection of legacy headerless `.rbs` payloads.
+- Binary-safe and empty-input-safe LZW processing.
+- Dedicated `FormatError` and `IntegrityError` exceptions.
+- `rbshard` command-line interface for pack, unpack, inspect, encode, decode, and version operations.
+- Formal container specification in `docs/FORMAT.md`.
+- Expanded automated tests for binary data, corruption, containers, and legacy compatibility.
+
+### Changed
+
+- `save_rbs` now writes versioned containers.
+- `load_rbs` auto-detects versioned containers while retaining legacy read compatibility.
+- LZW code serialization is explicitly little-endian and its dictionary is bounded to 16-bit codes.
+- Gem packaging now exposes the `rbshard` executable and keeps the GTK desktop stack out of core runtime dependencies.
+
+### Security
+
+- Documentation now explicitly distinguishes v1 integrity checking from authenticated encryption.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,24 @@
 
 All notable changes to RbShard will be documented in this file.
 
-The project follows semantic versioning for public releases. Container-format revisions are versioned independently through `RbShard::FORMAT_VERSION`.
+The project follows semantic versioning for public releases. Container-format revisions are versioned independently from gem releases.
 
 ## Unreleased
 
 ### Added
 
-- Authenticated `RBSH` v2 container format.
-- PBKDF2-HMAC-SHA256 password/key derivation with random 16-byte salts.
-- Twofish-CBC encryption with random 16-byte IVs for v2 containers.
-- Encrypt-then-MAC authentication using HMAC-SHA256 over the v2 header and ciphertext.
+- Streaming authenticated **RBS v3** file format.
+- Record-oriented v3 layout with independently authenticated encrypted chunks.
+- Authenticated v3 footer binding chunk order, chunk count, and total plaintext length.
+- `RbShard.pack_stream` / `RbShard.unpack_stream` IO APIs with bounded memory use.
+- `RbShard.pack_file` / `RbShard.unpack_file` helpers for large files.
+- Atomic destination commit on file unpack: failed authentication cannot replace an existing output with partial plaintext.
+- Configurable v3 chunk sizing with bounded parser limits and a 1 MiB default.
+- File metadata inspection that does not load complete archives into memory.
+- Authenticated `RBSH` v2 in-memory container format.
+- PBKDF2-HMAC-SHA256 password/key derivation with random salts.
+- Twofish-CBC encryption with random IVs for v2/v3 containers.
+- Encrypt-then-MAC authentication using HMAC-SHA256.
 - Bounded KDF iteration parsing to limit malicious-header work amplification.
 - Backward-compatible reading of RBS v1 containers and original headerless payloads.
 - `RbShard.pack`, `RbShard.unpack`, `RbShard.container?`, and `RbShard.inspect_rbs` helpers.
@@ -19,24 +27,29 @@ The project follows semantic versioning for public releases. Container-format re
 - Binary-safe and empty-input-safe LZW processing.
 - Dedicated `FormatError` and `IntegrityError` exceptions.
 - `rbshard` command-line interface for pack, unpack, inspect, encode, decode, and version operations.
-- CLI control for v2 PBKDF2 iteration count.
+- CLI controls for PBKDF2 iteration count and v3 chunk size.
 - Formal multi-version container specification in `docs/FORMAT.md`.
-- Expanded automated tests for binary data, randomized v2 output, authentication failures, v1 compatibility, file helpers, and CLI workflows.
+- Expanded automated tests for binary data, v2/v3 authentication failures, streaming, truncation, atomic output safety, compatibility, and CLI workflows.
 - Multi-version Ruby GitHub Actions CI.
 
 ### Changed
 
-- `save_rbs` now writes authenticated v2 containers.
-- `load_rbs` auto-detects v2, v1, and legacy formats.
+- CLI `pack` now streams input into RBS v3 instead of loading the complete file into memory.
+- CLI `unpack` uses the streaming reader for v3 and preserves v2/v1/legacy compatibility.
+- CLI `inspect` reads bounded file metadata instead of `File.binread`-ing the archive.
+- `save_rbs` continues to provide the in-memory v2 compatibility API; file workflows should prefer `pack_file`.
+- `load_rbs` auto-detects v3, v2, v1, and legacy formats when materialized in memory.
 - The legacy `encode` / `decode` API remains available only for compatibility-oriented raw payload workflows.
 - LZW code serialization is explicitly little-endian and its dictionary is bounded to 16-bit codes.
-- Gem packaging now exposes the `rbshard` executable and keeps the GTK desktop stack out of core runtime dependencies.
-- The web UI writes v2 containers for uploaded files and binds to loopback by default.
+- Gem packaging exposes the `rbshard` executable and keeps the GTK desktop stack out of core runtime dependencies.
+- The web UI writes authenticated v2 containers for uploaded files and binds to loopback by default.
 
 ### Security
 
-- New containers no longer use the legacy default Twofish mode; v2 explicitly selects CBC with a random IV.
-- V2 verifies HMAC authentication before decryption or decompression.
+- V3 authenticates every chunk before decryption/decompression and authenticates the complete chunk sequence with a final footer tag.
+- V3 file unpacking uses an atomic temporary destination so incomplete authentication never commits partial plaintext.
+- New authenticated containers explicitly select CBC with fresh IVs rather than relying on the legacy Twofish default mode.
+- V2/v3 verify HMAC authentication before decrypting protected ciphertext.
 - Encryption and authentication keys are independently derived from PBKDF2 output.
 - V1 remains readable but is documented as unauthenticated.
 - The project remains experimental and has not received a dedicated cryptographic audit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,35 @@ The project follows semantic versioning for public releases. Container-format re
 
 ### Added
 
-- Versioned `RBSH` v1 container format with magic bytes and payload length metadata.
-- SHA-256 plaintext integrity verification after decryption.
+- Authenticated `RBSH` v2 container format.
+- PBKDF2-HMAC-SHA256 password/key derivation with random 16-byte salts.
+- Twofish-CBC encryption with random 16-byte IVs for v2 containers.
+- Encrypt-then-MAC authentication using HMAC-SHA256 over the v2 header and ciphertext.
+- Bounded KDF iteration parsing to limit malicious-header work amplification.
+- Backward-compatible reading of RBS v1 containers and original headerless payloads.
 - `RbShard.pack`, `RbShard.unpack`, `RbShard.container?`, and `RbShard.inspect_rbs` helpers.
 - Optional rejection of legacy headerless `.rbs` payloads.
 - Binary-safe and empty-input-safe LZW processing.
 - Dedicated `FormatError` and `IntegrityError` exceptions.
 - `rbshard` command-line interface for pack, unpack, inspect, encode, decode, and version operations.
-- Formal container specification in `docs/FORMAT.md`.
-- Expanded automated tests for binary data, corruption, containers, and legacy compatibility.
+- CLI control for v2 PBKDF2 iteration count.
+- Formal multi-version container specification in `docs/FORMAT.md`.
+- Expanded automated tests for binary data, randomized v2 output, authentication failures, v1 compatibility, file helpers, and CLI workflows.
+- Multi-version Ruby GitHub Actions CI.
 
 ### Changed
 
-- `save_rbs` now writes versioned containers.
-- `load_rbs` auto-detects versioned containers while retaining legacy read compatibility.
+- `save_rbs` now writes authenticated v2 containers.
+- `load_rbs` auto-detects v2, v1, and legacy formats.
+- The legacy `encode` / `decode` API remains available only for compatibility-oriented raw payload workflows.
 - LZW code serialization is explicitly little-endian and its dictionary is bounded to 16-bit codes.
 - Gem packaging now exposes the `rbshard` executable and keeps the GTK desktop stack out of core runtime dependencies.
+- The web UI writes v2 containers for uploaded files and binds to loopback by default.
 
 ### Security
 
-- Documentation now explicitly distinguishes v1 integrity checking from authenticated encryption.
+- New containers no longer use the legacy default Twofish mode; v2 explicitly selects CBC with a random IV.
+- V2 verifies HMAC authentication before decryption or decompression.
+- Encryption and authentication keys are independently derived from PBKDF2 output.
+- V1 remains readable but is documented as unauthenticated.
+- The project remains experimental and has not received a dedicated cryptographic audit.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,4 +23,4 @@ DEPENDENCIES
   rbshard!
 
 BUNDLED WITH
-   2.6.7
+   2.4.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     rbshard (0.1.0)
       twofish (~> 1.0)
-      webrick (>= 1.8)
+      webrick (~> 1.8)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,52 +2,16 @@ PATH
   remote: .
   specs:
     rbshard (0.1.0)
-      gtk3 (>= 4.0)
       twofish (~> 1.0)
+      webrick (>= 1.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    atk (4.3.0)
-      glib2 (= 4.3.0)
-    cairo (1.18.4)
-      native-package-installer (>= 1.0.3)
-      pkg-config (>= 1.2.2)
-      red-colors
-    cairo-gobject (4.3.0)
-      cairo (>= 1.16.2)
-      glib2 (= 4.3.0)
-    fiddle (1.1.8)
-    gdk3 (4.3.0)
-      cairo-gobject (= 4.3.0)
-      gdk_pixbuf2 (= 4.3.0)
-      pango (= 4.3.0)
-    gdk_pixbuf2 (4.3.0)
-      gio2 (= 4.3.0)
-    gio2 (4.3.0)
-      fiddle
-      gobject-introspection (= 4.3.0)
-    glib2 (4.3.0)
-      native-package-installer (>= 1.0.3)
-      pkg-config (>= 1.3.5)
-    gobject-introspection (4.3.0)
-      glib2 (= 4.3.0)
-    gtk3 (4.3.0)
-      atk (= 4.3.0)
-      gdk3 (= 4.3.0)
-    json (2.13.2)
-    matrix (0.4.3)
     minitest (5.25.5)
-    native-package-installer (1.1.9)
-    pango (4.3.0)
-      cairo-gobject (= 4.3.0)
-      gobject-introspection (= 4.3.0)
-    pkg-config (1.6.2)
     rake (13.3.0)
-    red-colors (0.4.0)
-      json
-      matrix
     twofish (1.0.8)
+    webrick (1.9.2)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 rbshard 0.1.0
 
-RbShard is a small Ruby compression and encryption toolkit. It combines a compact LZW codec with Twofish encryption and provides a versioned `.rbs` container format for storing encrypted payloads.
+RbShard is a compact Ruby compression and encryption toolkit. It combines a binary-safe LZW codec with Twofish encryption and provides a versioned `.rbs` container format, command-line tooling, file helpers, and optional web/desktop interfaces.
 
 > **Security note:** RbShard is an experimental project, not a substitute for a professionally reviewed authenticated-encryption format. The v1 container adds corruption/wrong-key detection with SHA-256, but it does not provide cryptographic authentication against an active attacker. Do not use it as the sole protection for high-value secrets.
 
@@ -13,9 +13,36 @@ RbShard is a small Ruby compression and encryption toolkit. It combines a compac
 * Versioned, self-identifying `.rbs` containers
 * SHA-256 plaintext integrity verification after decryption
 * Legacy headerless `.rbs` read compatibility
+* First-class `rbshard` command-line interface
 * Convenience helpers for files and in-memory payloads
-* Experimental Sinatra-style web UI and GTK desktop UI
-* Minitest coverage for text, binary data, containers, corruption, and legacy files
+* Experimental WEBrick web UI and optional GTK desktop UI
+* Minitest coverage for core and CLI workflows
+* Multi-version Ruby CI
+* Formal container-format documentation
+
+## Architecture
+
+```text
+             +-------------------+
+             | Ruby API / CLI/UI |
+             +---------+---------+
+                       |
+              +--------v--------+
+              | RBS Container   |
+              | magic/version   |
+              | length/digest   |
+              +--------+--------+
+                       |
+              +--------v--------+
+              | Twofish crypto  |
+              +--------+--------+
+                       |
+              +--------v--------+
+              | LZW compression |
+              +-----------------+
+```
+
+The legacy `encode` / `decode` methods operate on the LZW + Twofish layers directly. New file-oriented APIs add the versioned container layer around that codec.
 
 ## Container format
 
@@ -29,9 +56,9 @@ New files written by `save_rbs` use format version 1:
 | Payload | variable | LZW-compressed data encrypted with Twofish |
 | Digest | 32 bytes | SHA-256 of the original plaintext |
 
-The header makes new archives distinguishable from older raw encrypted payloads. `load_rbs` automatically reads both formats by default.
+The header makes new archives distinguishable from older raw encrypted payloads. `load_rbs` automatically reads both formats by default. See [`docs/FORMAT.md`](docs/FORMAT.md) for the byte-level specification and parser requirements.
 
-## Usage
+## Ruby API
 
 ```ruby
 require 'rbshard'
@@ -47,7 +74,7 @@ puts original # => "Hello rbshard!"
 ### In-memory containers
 
 ```ruby
-archive = RbShard.pack('classified-ish text', key)
+archive = RbShard.pack('example text', key)
 metadata = RbShard.inspect_rbs(archive)
 # => { format: :container, version: 1, payload_bytes: ..., total_bytes: ... }
 
@@ -69,37 +96,77 @@ To reject old headerless files when loading from disk:
 RbShard.load_rbs('message.rbs', key, allow_legacy: false)
 ```
 
+## Command-line interface
+
+The gem exposes a `rbshard` executable. From a source checkout, use `ruby bin/rbshard` in place of `rbshard`.
+
+```sh
+# Pack a file using a key stored in an environment variable
+export RBSHARD_KEY='secretkey1234567'
+rbshard pack --key-env RBSHARD_KEY report.pdf report.rbs
+
+# Inspect metadata without decrypting
+rbshard inspect report.rbs
+
+# Restore the original file
+rbshard unpack --key-env RBSHARD_KEY report.rbs report.pdf
+```
+
+Keys can be supplied with `--key`, `--key-env`, or `--key-file`. `--key-env` and `--key-file` are preferable because direct command-line arguments may be visible to other local processes or shell history.
+
+The CLI also exposes `encode` and `decode` commands for the legacy raw codec and `unpack --no-legacy` for applications that want to reject headerless files.
+
 ## Web UI
 
-Start the experimental web interface with:
+Start the experimental local web interface with:
 
 ```sh
 ruby bin/rbshard_ui
 ```
 
-Then visit `http://localhost:4567`. The interface supports text and file encode/decode operations and validates user-supplied keys before processing.
+Then visit `http://127.0.0.1:4567`. File uploads are written as versioned `.rbs` containers, while text encode/decode retains the original Base64-wrapped raw codec for compatibility. The server binds to loopback by default; `BIND` and `PORT` environment variables can override its listener.
 
 ## Desktop UI
 
-Start the GTK desktop application with:
+The desktop interface requires the optional `gtk3` gem and its native platform dependencies:
 
 ```sh
+gem install gtk3
 ruby bin/rbshard_desktop
 ```
 
-The desktop UI provides text encode/decode operations, file encryption/decryption, open/save actions, clipboard support, clearing controls, error dialogs, and status messages.
+GTK is intentionally not a core gem dependency so command-line and server environments do not need to install a desktop stack. The UI provides text encode/decode operations, file encryption/decryption, open/save actions, clipboard support, clearing controls, error dialogs, and status messages.
 
 ## Development
 
-Install dependencies and run the test suite:
+Install the core development dependencies and run all tests:
 
 ```sh
 bundle install
-bundle exec ruby -Itest test/test_rbshard.rb
+bundle exec rake test
 ```
 
-The core library intentionally has a small public API. Changes to the on-disk container should introduce a new `FORMAT_VERSION` and retain an explicit migration/read path for older versions whenever practical.
+CI runs the suite across supported Ruby versions and smoke-tests the command-line executable. The core library intentionally has a small public API. Changes to the on-disk format should introduce a new `FORMAT_VERSION` and retain an explicit migration/read path for older versions whenever practical.
+
+## Repository layout
+
+```text
+bin/
+  rbshard             CLI
+  rbshard_ui          local WEBrick UI
+  rbshard_desktop     optional GTK UI
+lib/
+  rbshard.rb           core codec and container implementation
+  rbshard/version.rb   gem version
+docs/
+  FORMAT.md            RBS container specification
+test/
+  test_rbshard.rb      core tests
+  test_cli.rb          CLI integration tests
+```
 
 ## Roadmap
 
-Good next steps include replacing the v1 digest-only integrity scheme with a standard authenticated-encryption construction, streaming large files instead of buffering them entirely in memory, adding a command-line interface, fuzz/property tests for the LZW decoder and container parser, and publishing a formal format specification with test vectors.
+The next major format revision should replace the v1 digest-only integrity mechanism with a standard authenticated-encryption or encrypt-then-MAC construction. Additional priorities include password-based key derivation with explicit salts and parameters, streaming support for large files, fuzz/property testing of the parser and LZW decoder, portable test vectors, richer metadata, and reproducible release automation.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the current unreleased work.

--- a/README.md
+++ b/README.md
@@ -2,189 +2,215 @@
 
 rbshard 0.1.0
 
-RbShard is a compact Ruby compression and encryption toolkit. It combines a binary-safe LZW codec with Twofish encryption and provides a versioned `.rbs` container format, command-line tooling, file helpers, and optional web/desktop interfaces.
+RbShard is a compact Ruby compression and encryption toolkit. It combines a binary-safe LZW codec with Twofish encryption and provides versioned `.rbs` containers, streaming file workflows, a command-line interface, file helpers, and optional web/desktop interfaces.
 
-> **Security note:** RbShard remains experimental and unaudited. New RBS v2 containers use PBKDF2-HMAC-SHA256, randomized Twofish-CBC, and encrypt-then-HMAC authentication, but high-value or regulated secrets should still use a mature audited encryption format. See [`SECURITY.md`](SECURITY.md).
+> **Security note:** RbShard remains experimental and unaudited. RBS v2/v3 use PBKDF2-HMAC-SHA256, randomized Twofish-CBC, and encrypt-then-HMAC authentication, but high-value or regulated secrets should still use a mature audited encryption format. See [`SECURITY.md`](SECURITY.md).
 
 ## Features
 
-* Binary-safe LZW compression and decompression
-* Authenticated RBS v2 containers
+* Streaming authenticated **RBS v3** for large files
+* Bounded-memory chunked compression/encryption/decryption
+* Per-chunk HMAC verification plus authenticated final footer
+* Atomic destination commit after complete v3 verification
+* Authenticated in-memory RBS v2 containers
 * PBKDF2-HMAC-SHA256 key derivation with random salts
-* Twofish-CBC encryption with random IVs
+* Twofish-CBC encryption with fresh random IVs
 * HMAC-SHA256 encrypt-then-MAC authentication
 * Backward-compatible RBS v1 and headerless legacy readers
-* First-class `rbshard` command-line interface
-* Convenience helpers for files and in-memory payloads
+* Binary-safe LZW compression and decompression
+* First-class `rbshard` CLI
+* Metadata inspection without loading whole archives
 * Experimental WEBrick web UI and optional GTK desktop UI
-* Core and CLI Minitest coverage
-* Multi-version Ruby CI
-* Formal container-format and security documentation
+* Core, streaming, and CLI Minitest coverage
+* Multi-version Ruby CI and release-gated gem publishing
+* Formal multi-version container specification
 
 ## Architecture
 
 ```text
-             +-------------------+
-             | Ruby API / CLI/UI |
-             +---------+---------+
-                       |
-              +--------v---------+
-              | RBS v2 container|
-              | version / KDF    |
-              | salt / IV / HMAC |
-              +--------+---------+
-                       |
-              +--------v---------+
-              | Twofish-CBC      |
-              +--------+---------+
-                       |
-              +--------v---------+
-              | LZW compression  |
-              +------------------+
+                 +---------------------+
+                 | Ruby API / CLI / UI |
+                 +----------+----------+
+                            |
+              +-------------+-------------+
+              |                           |
+       +------v-------+            +------v-------+
+       | RBS v3 file |            | RBS v2 memory|
+       | chunk stream|            | single blob  |
+       +------+-------+            +------+-------+
+              |                           |
+       +------v---------------------------v------+
+       | PBKDF2 -> Twofish-CBC -> HMAC-SHA256   |
+       +------------------+---------------------+
+                          |
+                   +------v-------+
+                   | LZW codec    |
+                   +--------------+
 ```
 
-The legacy `encode` / `decode` methods operate on the original LZW + Twofish path directly. New file-oriented APIs use authenticated v2 containers. Readers can still open v1 and original headerless payloads.
+The original `encode` / `decode` methods remain available only for compatibility with headerless legacy payloads.
 
-## Container format
+## RBS v3 streaming format
 
-New files written by `save_rbs` use **RBS v2**:
+File workflows now use **RBS v3**. A v3 archive contains:
 
-| Field | Size | Description |
-| --- | ---: | --- |
-| Magic | 4 bytes | ASCII `RBSH` |
-| Version | 1 byte | `2` |
-| KDF iterations | 4 bytes | PBKDF2 iteration count, little-endian |
-| Salt | 16 bytes | Random PBKDF2 salt |
-| IV | 16 bytes | Random Twofish-CBC IV |
-| Payload length | 4 bytes | Encrypted payload length, little-endian |
-| Payload | variable | LZW-compressed, Twofish-CBC encrypted data |
-| Authentication tag | 32 bytes | HMAC-SHA256 over header + ciphertext |
+```text
+RBSH v3 header
+    |
+    +-- CHNK 0: lengths + IV + ciphertext + HMAC
+    +-- CHNK 1: lengths + IV + ciphertext + HMAC
+    +-- ...
+    |
+    `-- END!: chunk count + plaintext length + final HMAC
+```
 
-The supplied password/key is expanded with PBKDF2-HMAC-SHA256 into separate 32-byte encryption and authentication keys. The current writer default is 200,000 PBKDF2 iterations.
+Each plaintext chunk is compressed independently with LZW, encrypted independently with Twofish-CBC and a fresh IV, and authenticated before decryption. The footer authenticates the ordered sequence of chunk tags and aggregate counts, detecting truncation or reordering.
 
-See [`docs/FORMAT.md`](docs/FORMAT.md) for the byte-level v2 specification, v1 compatibility layout, and parser requirements.
+The default plaintext chunk size is **1 MiB**. The current implementation accepts 1 KiB through 64 MiB chunks.
+
+`unpack_file` writes to a temporary destination and atomically renames it only after the final footer validates, so a failed password/authentication check cannot replace an existing destination with partially verified plaintext.
+
+See [`docs/FORMAT.md`](docs/FORMAT.md) for the byte-level v3/v2/v1 specification.
+
+## Command-line interface
+
+The gem exposes a `rbshard` executable. From a source checkout, use `ruby bin/rbshard`.
+
+```sh
+export RBSHARD_KEY='correct horse battery staple'
+
+# Stream a large file into RBS v3
+rbshard pack --key-env RBSHARD_KEY disk-image.bin disk-image.rbs
+
+# Inspect metadata without reading the whole archive
+rbshard inspect disk-image.rbs
+
+# Stream and atomically restore the original file
+rbshard unpack --key-env RBSHARD_KEY disk-image.rbs disk-image.bin
+```
+
+For controlled testing/interoperability:
+
+```sh
+rbshard pack \
+  --chunk-size 4194304 \
+  --kdf-iterations 200000 \
+  --key-env RBSHARD_KEY \
+  input.bin output.rbs
+```
+
+Keys can be supplied with `--key`, `--key-env`, or `--key-file`. `--key-env` and `--key-file` are preferable because direct arguments may appear in process listings or shell history.
+
+`unpack --no-legacy` rejects original headerless payloads. `encode` and `decode` expose the old raw codec for compatibility only.
 
 ## Ruby API
+
+### Streaming files
 
 ```ruby
 require 'rbshard'
 
-data = 'Hello rbshard!'
-key = 'secretkey1234567'
+key = 'correct horse battery staple'
 
-RbShard.save_rbs('message.rbs', data, key)
-original = RbShard.load_rbs('message.rbs', key)
-puts original # => "Hello rbshard!"
+metadata = RbShard.pack_file(
+  'backup.tar',
+  'backup.rbs',
+  key,
+  chunk_size: 4 * 1024 * 1024
+)
+
+RbShard.unpack_file('backup.rbs', 'backup-restored.tar', key)
 ```
 
-### In-memory containers
+### Streaming IO
 
 ```ruby
-archive = RbShard.pack('example text', key)
-metadata = RbShard.inspect_rbs(archive)
-# => {
-#   format: :container,
-#   version: 2,
-#   authenticated: true,
-#   kdf: :'pbkdf2-hmac-sha256',
-#   cipher: :'twofish-cbc',
-#   ...
-# }
+File.open('input.bin', 'rb') do |input|
+  File.open('output.rbs', 'wb') do |output|
+    RbShard.pack_stream(input, output, key)
+  end
+end
+```
 
+`RbShard.unpack_stream` accepts input/output IO objects and authenticates each chunk before writing its plaintext.
+
+### In-memory v2 containers
+
+```ruby
+archive = RbShard.pack('small message', key)
 plaintext = RbShard.unpack(archive, key)
 ```
 
+The in-memory API intentionally remains v2; large file workflows should use `pack_file` / `unpack_file`.
+
 ### Compatibility API
 
-`encode` and `decode` remain available for original headerless payloads:
-
 ```ruby
-encoded = RbShard.encode(data, key)
-decoded = RbShard.decode(encoded, key)
+encoded = RbShard.encode('legacy data', 'secretkey1234567')
+decoded = RbShard.decode(encoded, 'secretkey1234567')
 ```
 
-That path preserves historical behavior for compatibility and should not be selected for new encrypted file formats.
+Readers understand v3, v2, v1, and headerless legacy inputs.
 
-To reject headerless files when loading from disk:
+## Format compatibility
 
-```ruby
-RbShard.load_rbs('message.rbs', key, allow_legacy: false)
-```
-
-RBS v1 containers remain readable automatically.
-
-## Command-line interface
-
-The gem exposes a `rbshard` executable. From a source checkout, use `ruby bin/rbshard` in place of `rbshard`.
-
-```sh
-# Pack a file using a key stored in an environment variable
-export RBSHARD_KEY='correct horse battery staple'
-rbshard pack --key-env RBSHARD_KEY report.pdf report.rbs
-
-# Inspect metadata without decrypting
-rbshard inspect report.rbs
-
-# Restore the original file
-rbshard unpack --key-env RBSHARD_KEY report.rbs report.pdf
-```
-
-Keys can be supplied with `--key`, `--key-env`, or `--key-file`. `--key-env` and `--key-file` are preferable because direct command-line arguments may be visible to other local processes or shell history.
-
-`pack --kdf-iterations N` is available for controlled interoperability/testing scenarios. Production users should normally retain the default rather than reducing the work factor.
-
-The CLI also exposes `encode` and `decode` commands for the legacy raw codec and `unpack --no-legacy` for applications that want to reject headerless files.
+| Format | Read | Write | Authentication | Streaming |
+| --- | --- | --- | --- | --- |
+| Headerless legacy | yes | raw API | no | no |
+| RBS v1 | yes | no | no | no |
+| RBS v2 | yes | in-memory API | yes | no |
+| RBS v3 | yes | file/stream API + CLI | yes | yes |
 
 ## Web UI
 
-Start the experimental local web interface with:
+Start the experimental local interface with:
 
 ```sh
 ruby bin/rbshard_ui
 ```
 
-Then visit `http://127.0.0.1:4567`. File uploads are written as authenticated v2 `.rbs` containers, while text encode/decode retains the original Base64-wrapped raw codec for compatibility. The server binds to loopback by default; `BIND` and `PORT` environment variables can override its listener.
+Then visit `http://127.0.0.1:4567`. The server binds to loopback by default. The web UI currently uses authenticated v2 for uploaded files; the CLI/file API is the preferred v3 path for large objects.
 
 ## Desktop UI
 
-The desktop interface requires the optional `gtk3` gem and its native platform dependencies:
+The optional GTK desktop interface requires:
 
 ```sh
 gem install gtk3
 ruby bin/rbshard_desktop
 ```
 
-GTK is intentionally not a core gem dependency so command-line and server environments do not need to install a desktop stack. The UI provides text encode/decode operations, file encryption/decryption, open/save actions, clipboard support, clearing controls, error dialogs, and status messages.
+GTK is intentionally excluded from core runtime dependencies.
 
 ## Development
-
-Install the core development dependencies and run all tests:
 
 ```sh
 bundle install
 bundle exec rake test
 ```
 
-CI runs the suite across supported Ruby versions and smoke-tests the command-line executable. Test code can lower the PBKDF2 iteration count to the accepted minimum to keep the suite fast while still exercising the v2 path.
-
-The on-disk container version is independent of the gem version. Any future format change should increment `FORMAT_VERSION` and preserve an explicit migration/read path whenever practical.
+The suite includes core container tests, streaming integrity/atomicity tests, and CLI integration tests. GitHub Actions covers Ruby 3.0 through 3.4. Gem packaging is built on pull requests, while publication is restricted to published releases.
 
 ## Repository layout
 
 ```text
 .github/workflows/
-  ci.yml              Ruby test matrix
+  ci.yml              main Ruby test matrix
+  ruby.yml            compatibility matrix
+  gem-push.yml        build-on-PR / publish-on-release
 bin/
-  rbshard             CLI
+  rbshard             streaming CLI
   rbshard_ui          local WEBrick UI
   rbshard_desktop     optional GTK UI
 lib/
-  rbshard.rb           core codec and container implementation
+  rbshard.rb           core codec + v1/v2 compatibility
+  rbshard/stream.rb    streaming RBS v3 engine
   rbshard/version.rb   gem version
 docs/
-  FORMAT.md            RBS container specification
+  FORMAT.md            byte-level format specification
 test/
   test_rbshard.rb      core/container tests
+  test_stream.rb       streaming/integrity/atomicity tests
   test_cli.rb          CLI integration tests
 CHANGELOG.md           unreleased/release changes
 SECURITY.md            security model and reporting guidance
@@ -192,6 +218,6 @@ SECURITY.md            security model and reporting guidance
 
 ## Roadmap
 
-Next priorities are streaming encryption/decryption for large files, fuzz/property testing of the parser and LZW decoder, portable interoperability test vectors, richer authenticated metadata, safer secret-entry UX, reproducible release automation, and eventually evaluating whether a more modern audited cryptographic dependency should replace the legacy Twofish implementation entirely.
+With chunked streaming implemented, the next expansion targets are **property/fuzz testing**, portable interoperability test vectors, richer authenticated metadata, resumable/parallel chunk processing, safer interactive secret entry, reproducible releases, and evaluating a modern audited cryptographic backend while retaining RBS compatibility.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for the current unreleased work.

--- a/README.md
+++ b/README.md
@@ -4,21 +4,22 @@ rbshard 0.1.0
 
 RbShard is a compact Ruby compression and encryption toolkit. It combines a binary-safe LZW codec with Twofish encryption and provides a versioned `.rbs` container format, command-line tooling, file helpers, and optional web/desktop interfaces.
 
-> **Security note:** RbShard is an experimental project, not a substitute for a professionally reviewed authenticated-encryption format. The v1 container adds corruption/wrong-key detection with SHA-256, but it does not provide cryptographic authentication against an active attacker. Do not use it as the sole protection for high-value secrets.
+> **Security note:** RbShard remains experimental and unaudited. New RBS v2 containers use PBKDF2-HMAC-SHA256, randomized Twofish-CBC, and encrypt-then-HMAC authentication, but high-value or regulated secrets should still use a mature audited encryption format. See [`SECURITY.md`](SECURITY.md).
 
 ## Features
 
 * Binary-safe LZW compression and decompression
-* Twofish encryption and decryption
-* Versioned, self-identifying `.rbs` containers
-* SHA-256 plaintext integrity verification after decryption
-* Legacy headerless `.rbs` read compatibility
+* Authenticated RBS v2 containers
+* PBKDF2-HMAC-SHA256 key derivation with random salts
+* Twofish-CBC encryption with random IVs
+* HMAC-SHA256 encrypt-then-MAC authentication
+* Backward-compatible RBS v1 and headerless legacy readers
 * First-class `rbshard` command-line interface
 * Convenience helpers for files and in-memory payloads
 * Experimental WEBrick web UI and optional GTK desktop UI
-* Minitest coverage for core and CLI workflows
+* Core and CLI Minitest coverage
 * Multi-version Ruby CI
-* Formal container-format documentation
+* Formal container-format and security documentation
 
 ## Architecture
 
@@ -27,36 +28,41 @@ RbShard is a compact Ruby compression and encryption toolkit. It combines a bina
              | Ruby API / CLI/UI |
              +---------+---------+
                        |
-              +--------v--------+
-              | RBS Container   |
-              | magic/version   |
-              | length/digest   |
-              +--------+--------+
+              +--------v---------+
+              | RBS v2 container|
+              | version / KDF    |
+              | salt / IV / HMAC |
+              +--------+---------+
                        |
-              +--------v--------+
-              | Twofish crypto  |
-              +--------+--------+
+              +--------v---------+
+              | Twofish-CBC      |
+              +--------+---------+
                        |
-              +--------v--------+
-              | LZW compression |
-              +-----------------+
+              +--------v---------+
+              | LZW compression  |
+              +------------------+
 ```
 
-The legacy `encode` / `decode` methods operate on the LZW + Twofish layers directly. New file-oriented APIs add the versioned container layer around that codec.
+The legacy `encode` / `decode` methods operate on the original LZW + Twofish path directly. New file-oriented APIs use authenticated v2 containers. Readers can still open v1 and original headerless payloads.
 
 ## Container format
 
-New files written by `save_rbs` use format version 1:
+New files written by `save_rbs` use **RBS v2**:
 
 | Field | Size | Description |
 | --- | ---: | --- |
 | Magic | 4 bytes | ASCII `RBSH` |
-| Version | 1 byte | Currently `1` |
-| Payload length | 4 bytes | Little-endian encrypted payload length |
-| Payload | variable | LZW-compressed data encrypted with Twofish |
-| Digest | 32 bytes | SHA-256 of the original plaintext |
+| Version | 1 byte | `2` |
+| KDF iterations | 4 bytes | PBKDF2 iteration count, little-endian |
+| Salt | 16 bytes | Random PBKDF2 salt |
+| IV | 16 bytes | Random Twofish-CBC IV |
+| Payload length | 4 bytes | Encrypted payload length, little-endian |
+| Payload | variable | LZW-compressed, Twofish-CBC encrypted data |
+| Authentication tag | 32 bytes | HMAC-SHA256 over header + ciphertext |
 
-The header makes new archives distinguishable from older raw encrypted payloads. `load_rbs` automatically reads both formats by default. See [`docs/FORMAT.md`](docs/FORMAT.md) for the byte-level specification and parser requirements.
+The supplied password/key is expanded with PBKDF2-HMAC-SHA256 into separate 32-byte encryption and authentication keys. The current writer default is 200,000 PBKDF2 iterations.
+
+See [`docs/FORMAT.md`](docs/FORMAT.md) for the byte-level v2 specification, v1 compatibility layout, and parser requirements.
 
 ## Ruby API
 
@@ -76,25 +82,36 @@ puts original # => "Hello rbshard!"
 ```ruby
 archive = RbShard.pack('example text', key)
 metadata = RbShard.inspect_rbs(archive)
-# => { format: :container, version: 1, payload_bytes: ..., total_bytes: ... }
+# => {
+#   format: :container,
+#   version: 2,
+#   authenticated: true,
+#   kdf: :'pbkdf2-hmac-sha256',
+#   cipher: :'twofish-cbc',
+#   ...
+# }
 
 plaintext = RbShard.unpack(archive, key)
 ```
 
-### Legacy codec API
+### Compatibility API
 
-`encode` and `decode` remain available and produce/consume the original headerless encrypted representation:
+`encode` and `decode` remain available for original headerless payloads:
 
 ```ruby
 encoded = RbShard.encode(data, key)
 decoded = RbShard.decode(encoded, key)
 ```
 
-To reject old headerless files when loading from disk:
+That path preserves historical behavior for compatibility and should not be selected for new encrypted file formats.
+
+To reject headerless files when loading from disk:
 
 ```ruby
 RbShard.load_rbs('message.rbs', key, allow_legacy: false)
 ```
+
+RBS v1 containers remain readable automatically.
 
 ## Command-line interface
 
@@ -102,7 +119,7 @@ The gem exposes a `rbshard` executable. From a source checkout, use `ruby bin/rb
 
 ```sh
 # Pack a file using a key stored in an environment variable
-export RBSHARD_KEY='secretkey1234567'
+export RBSHARD_KEY='correct horse battery staple'
 rbshard pack --key-env RBSHARD_KEY report.pdf report.rbs
 
 # Inspect metadata without decrypting
@@ -114,6 +131,8 @@ rbshard unpack --key-env RBSHARD_KEY report.rbs report.pdf
 
 Keys can be supplied with `--key`, `--key-env`, or `--key-file`. `--key-env` and `--key-file` are preferable because direct command-line arguments may be visible to other local processes or shell history.
 
+`pack --kdf-iterations N` is available for controlled interoperability/testing scenarios. Production users should normally retain the default rather than reducing the work factor.
+
 The CLI also exposes `encode` and `decode` commands for the legacy raw codec and `unpack --no-legacy` for applications that want to reject headerless files.
 
 ## Web UI
@@ -124,7 +143,7 @@ Start the experimental local web interface with:
 ruby bin/rbshard_ui
 ```
 
-Then visit `http://127.0.0.1:4567`. File uploads are written as versioned `.rbs` containers, while text encode/decode retains the original Base64-wrapped raw codec for compatibility. The server binds to loopback by default; `BIND` and `PORT` environment variables can override its listener.
+Then visit `http://127.0.0.1:4567`. File uploads are written as authenticated v2 `.rbs` containers, while text encode/decode retains the original Base64-wrapped raw codec for compatibility. The server binds to loopback by default; `BIND` and `PORT` environment variables can override its listener.
 
 ## Desktop UI
 
@@ -146,11 +165,15 @@ bundle install
 bundle exec rake test
 ```
 
-CI runs the suite across supported Ruby versions and smoke-tests the command-line executable. The core library intentionally has a small public API. Changes to the on-disk format should introduce a new `FORMAT_VERSION` and retain an explicit migration/read path for older versions whenever practical.
+CI runs the suite across supported Ruby versions and smoke-tests the command-line executable. Test code can lower the PBKDF2 iteration count to the accepted minimum to keep the suite fast while still exercising the v2 path.
+
+The on-disk container version is independent of the gem version. Any future format change should increment `FORMAT_VERSION` and preserve an explicit migration/read path whenever practical.
 
 ## Repository layout
 
 ```text
+.github/workflows/
+  ci.yml              Ruby test matrix
 bin/
   rbshard             CLI
   rbshard_ui          local WEBrick UI
@@ -161,12 +184,14 @@ lib/
 docs/
   FORMAT.md            RBS container specification
 test/
-  test_rbshard.rb      core tests
+  test_rbshard.rb      core/container tests
   test_cli.rb          CLI integration tests
+CHANGELOG.md           unreleased/release changes
+SECURITY.md            security model and reporting guidance
 ```
 
 ## Roadmap
 
-The next major format revision should replace the v1 digest-only integrity mechanism with a standard authenticated-encryption or encrypt-then-MAC construction. Additional priorities include password-based key derivation with explicit salts and parameters, streaming support for large files, fuzz/property testing of the parser and LZW decoder, portable test vectors, richer metadata, and reproducible release automation.
+Next priorities are streaming encryption/decryption for large files, fuzz/property testing of the parser and LZW decoder, portable interoperability test vectors, richer authenticated metadata, safer secret-entry UX, reproducible release automation, and eventually evaluating whether a more modern audited cryptographic dependency should replace the legacy Twofish implementation entirely.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for the current unreleased work.

--- a/README.md
+++ b/README.md
@@ -2,61 +2,104 @@
 
 rbshard 0.1.0
 
-RbShard provides simple compression and encryption utilities built in Ruby.
-Compression is performed with a minimal LZW implementation and data is
-encrypted using the Twofish cipher. Files stored with the `.rbs` extension
-contain compressed and encrypted payloads.
+RbShard is a small Ruby compression and encryption toolkit. It combines a compact LZW codec with Twofish encryption and provides a versioned `.rbs` container format for storing encrypted payloads.
+
+> **Security note:** RbShard is an experimental project, not a substitute for a professionally reviewed authenticated-encryption format. The v1 container adds corruption/wrong-key detection with SHA-256, but it does not provide cryptographic authentication against an active attacker. Do not use it as the sole protection for high-value secrets.
 
 ## Features
 
-* LZW based compression and decompression
+* Binary-safe LZW compression and decompression
 * Twofish encryption and decryption
-* Convenience helpers to read and write `.rbs` files
+* Versioned, self-identifying `.rbs` containers
+* SHA-256 plaintext integrity verification after decryption
+* Legacy headerless `.rbs` read compatibility
+* Convenience helpers for files and in-memory payloads
+* Experimental Sinatra-style web UI and GTK desktop UI
+* Minitest coverage for text, binary data, containers, corruption, and legacy files
+
+## Container format
+
+New files written by `save_rbs` use format version 1:
+
+| Field | Size | Description |
+| --- | ---: | --- |
+| Magic | 4 bytes | ASCII `RBSH` |
+| Version | 1 byte | Currently `1` |
+| Payload length | 4 bytes | Little-endian encrypted payload length |
+| Payload | variable | LZW-compressed data encrypted with Twofish |
+| Digest | 32 bytes | SHA-256 of the original plaintext |
+
+The header makes new archives distinguishable from older raw encrypted payloads. `load_rbs` automatically reads both formats by default.
 
 ## Usage
 
-```
+```ruby
 require 'rbshard'
 
 data = 'Hello rbshard!'
 key = 'secretkey1234567'
 
-# Encode and save a file
 RbShard.save_rbs('message.rbs', data, key)
-
-# Load and decode
 original = RbShard.load_rbs('message.rbs', key)
 puts original # => "Hello rbshard!"
 ```
 
+### In-memory containers
+
+```ruby
+archive = RbShard.pack('classified-ish text', key)
+metadata = RbShard.inspect_rbs(archive)
+# => { format: :container, version: 1, payload_bytes: ..., total_bytes: ... }
+
+plaintext = RbShard.unpack(archive, key)
+```
+
+### Legacy codec API
+
+`encode` and `decode` remain available and produce/consume the original headerless encrypted representation:
+
+```ruby
+encoded = RbShard.encode(data, key)
+decoded = RbShard.decode(encoded, key)
+```
+
+To reject old headerless files when loading from disk:
+
+```ruby
+RbShard.load_rbs('message.rbs', key, allow_legacy: false)
+```
+
 ## Web UI
 
-An experimental web interface is provided to quickly try out encoding and
-decoding operations. Start the server with:
+Start the experimental web interface with:
 
-```
+```sh
 ruby bin/rbshard_ui
 ```
 
-Then visit `http://localhost:4567` in your browser to access forms for encoding
-and decoding text using a secret key. Keys must be at least eight characters
-long. You can paste text directly or upload files to encode and decode. The
-interface escapes displayed results for better security and will return encoded
-or decoded files for download when using the upload options.
-Feedback is welcome as the UI continues to evolve.
+Then visit `http://localhost:4567`. The interface supports text and file encode/decode operations and validates user-supplied keys before processing.
 
 ## Desktop UI
 
-You can also use a simple GTK-based desktop application to run encode and
-decode operations locally:
+Start the GTK desktop application with:
 
-```
+```sh
 ruby bin/rbshard_desktop
 ```
 
-This opens a window with text areas for input and results along with an entry
-field for your secret key. A simple menu provides options to open files for
-encoding, save results to disk and quit the application. Additional menu items
-allow encrypting and decrypting arbitrary files such as PDFs or text documents
-directly to and from `.rbs` archives. Keys must be at least eight characters
-long and invalid operations will show an error dialog.
+The desktop UI provides text encode/decode operations, file encryption/decryption, open/save actions, clipboard support, clearing controls, error dialogs, and status messages.
+
+## Development
+
+Install dependencies and run the test suite:
+
+```sh
+bundle install
+bundle exec ruby -Itest test/test_rbshard.rb
+```
+
+The core library intentionally has a small public API. Changes to the on-disk container should introduce a new `FORMAT_VERSION` and retain an explicit migration/read path for older versions whenever practical.
+
+## Roadmap
+
+Good next steps include replacing the v1 digest-only integrity scheme with a standard authenticated-encryption construction, streaming large files instead of buffering them entirely in memory, adding a command-line interface, fuzz/property tests for the LZW decoder and container parser, and publishing a formal format specification with test vectors.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+RbShard is an experimental encryption/container project. It should not be treated as independently audited cryptographic software.
+
+## Supported formats
+
+New files are written using RBS format version 2. Version 2 uses PBKDF2-HMAC-SHA256, Twofish-CBC with a random IV, and encrypt-then-MAC authentication with HMAC-SHA256.
+
+Version 1 and original headerless payloads remain readable for compatibility, but they do not provide the same security properties as version 2. In particular, version 1 is not authenticated and the headerless legacy codec preserves the historical raw Twofish behavior.
+
+## Security expectations
+
+For new data:
+
+- prefer `RbShard.pack`, `RbShard.save_rbs`, or the `rbshard pack` command;
+- avoid the legacy `encode` API unless compatibility requires it;
+- use high-entropy keys or strong passphrases;
+- prefer `--key-env` or `--key-file` over `--key` in shell workflows;
+- keep encrypted archives and key material in separate trust domains when practical; and
+- do not weaken PBKDF2 iteration counts merely for convenience outside controlled test environments.
+
+## Threat-model limitations
+
+RbShard v2 authenticates its header and ciphertext before decryption, but the implementation still has important limitations:
+
+- the Twofish dependency is implemented in pure Ruby and may not provide constant-time behavior;
+- secret material lives in Ruby-managed memory and is not reliably zeroized;
+- whole files are currently buffered in memory;
+- metadata such as total archive size is visible;
+- local endpoint security, shell history, environment exposure, filesystem permissions, swap, backups, and process inspection are outside the container format's protection; and
+- the project has not undergone an independent cryptographic or implementation audit.
+
+For high-value or regulated secrets, use a mature audited encryption format/library appropriate to the environment rather than relying solely on RbShard.
+
+## Reporting a vulnerability
+
+Please avoid publishing exploitable details in a public issue before the maintainer has had a reasonable opportunity to assess them. Use GitHub's private security-reporting feature when enabled for the repository. If private reporting is unavailable, open a minimal public issue requesting a private contact channel without including exploit details.
+
+A useful report should include the affected version/commit, the relevant container format version, reproduction conditions, expected versus observed behavior, and the security impact.

--- a/bin/rbshard
+++ b/bin/rbshard
@@ -1,0 +1,156 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+require_relative '../lib/rbshard'
+
+module RbShardCLI
+  module_function
+
+  def run(argv)
+    command = argv.shift
+    case command
+    when 'pack'
+      pack_command(argv)
+    when 'unpack'
+      unpack_command(argv)
+    when 'inspect'
+      inspect_command(argv)
+    when 'encode'
+      transform_command(argv, :encode)
+    when 'decode'
+      transform_command(argv, :decode)
+    when 'version', '--version', '-v'
+      puts RbShard::VERSION
+      0
+    when 'help', '--help', '-h', nil
+      puts help_text
+      command.nil? ? 1 : 0
+    else
+      warn "Unknown command: #{command}"
+      warn help_text
+      1
+    end
+  rescue OptionParser::ParseError, ArgumentError, RbShard::Error => e
+    warn "rbshard: #{e.message}"
+    2
+  rescue Errno::ENOENT, Errno::EACCES => e
+    warn "rbshard: #{e.message}"
+    3
+  end
+
+  def pack_command(argv)
+    options = common_io_options('Pack plaintext into a versioned .rbs container')
+    key_options(options)
+    config, paths = parse(options, argv)
+    input, output = require_paths(paths)
+    key = resolve_key(config)
+    RbShard.save_rbs(output, File.binread(input), key)
+    puts "Packed #{input} -> #{output}"
+    0
+  end
+
+  def unpack_command(argv)
+    config = { allow_legacy: true }
+    options = common_io_options('Unpack a .rbs container to plaintext')
+    key_options(options)
+    options.on('--no-legacy', 'Reject legacy headerless payloads') { config[:allow_legacy] = false }
+    parsed, paths = parse(options, argv, config)
+    input, output = require_paths(paths)
+    key = resolve_key(parsed)
+    plaintext = RbShard.load_rbs(input, key, allow_legacy: parsed[:allow_legacy])
+    File.binwrite(output, plaintext)
+    puts "Unpacked #{input} -> #{output}"
+    0
+  end
+
+  def inspect_command(argv)
+    options = OptionParser.new do |opts|
+      opts.banner = 'Usage: rbshard inspect FILE'
+      opts.on('-h', '--help', 'Show help') { puts opts; exit 0 }
+    end
+    _config, paths = parse(options, argv)
+    raise ArgumentError, 'inspect requires exactly one FILE' unless paths.length == 1
+
+    metadata = RbShard.inspect_rbs(File.binread(paths.first))
+    metadata.each { |key, value| puts "#{key}: #{value}" }
+    0
+  end
+
+  def transform_command(argv, operation)
+    options = common_io_options("#{operation.to_s.capitalize} using the legacy raw codec")
+    key_options(options)
+    config, paths = parse(options, argv)
+    input, output = require_paths(paths)
+    key = resolve_key(config)
+    result = RbShard.public_send(operation, File.binread(input), key)
+    File.binwrite(output, result)
+    puts "#{operation.to_s.capitalize}d #{input} -> #{output}"
+    0
+  end
+
+  def common_io_options(description)
+    OptionParser.new do |opts|
+      opts.banner = "#{description}\nUsage: rbshard #{description.split.first.downcase} [options] INPUT OUTPUT"
+      opts.on('-h', '--help', 'Show help') { puts opts; exit 0 }
+    end
+  end
+
+  def key_options(options)
+    options.on('-k', '--key KEY', 'Encryption key (discouraged: visible in process arguments)') { |value| @inline_key = value }
+    options.on('--key-env NAME', 'Read key from environment variable NAME') { |value| @key_env = value }
+    options.on('--key-file FILE', 'Read key bytes from FILE') { |value| @key_file = value }
+  end
+
+  def parse(options, argv, initial = {})
+    @inline_key = nil
+    @key_env = nil
+    @key_file = nil
+    paths = options.parse(argv)
+    [initial.merge(inline_key: @inline_key, key_env: @key_env, key_file: @key_file), paths]
+  end
+
+  def require_paths(paths)
+    raise ArgumentError, 'command requires INPUT and OUTPUT paths' unless paths.length == 2
+    paths
+  end
+
+  def resolve_key(config)
+    sources = [config[:inline_key], config[:key_env], config[:key_file]].compact
+    raise ArgumentError, 'provide exactly one of --key, --key-env, or --key-file' unless sources.length == 1
+
+    return config[:inline_key] if config[:inline_key]
+
+    if config[:key_env]
+      value = ENV[config[:key_env]]
+      raise ArgumentError, "environment variable #{config[:key_env]} is not set" if value.nil?
+      return value
+    end
+
+    File.binread(config[:key_file]).sub(/\r?\n\z/, '')
+  end
+
+  def help_text
+    <<~HELP
+      RbShard #{RbShard::VERSION}
+
+      Usage: rbshard COMMAND [options]
+
+      Commands:
+        pack INPUT OUTPUT       Create a versioned .rbs container
+        unpack INPUT OUTPUT     Restore plaintext from a .rbs file
+        inspect FILE            Display container metadata without decrypting
+        encode INPUT OUTPUT     Use the legacy raw encode codec
+        decode INPUT OUTPUT     Use the legacy raw decode codec
+        version                 Print the installed version
+        help                    Show this help
+
+      Key input for encryption/decryption commands:
+        --key KEY               Pass a key directly (least private)
+        --key-env NAME          Read the key from an environment variable
+        --key-file FILE         Read the key from a file
+    HELP
+  end
+end
+
+exit RbShardCLI.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/bin/rbshard
+++ b/bin/rbshard
@@ -40,12 +40,14 @@ module RbShardCLI
   end
 
   def pack_command(argv)
+    config = { kdf_iterations: RbShard::V2_KDF_ITERATIONS }
     options = common_io_options('Pack plaintext into a versioned .rbs container')
     key_options(options)
-    config, paths = parse(options, argv)
+    options.on('--kdf-iterations N', Integer, 'PBKDF2 iterations for new v2 archives') { |value| config[:kdf_iterations] = value }
+    parsed, paths = parse(options, argv, config)
     input, output = require_paths(paths)
-    key = resolve_key(config)
-    RbShard.save_rbs(output, File.binread(input), key)
+    key = resolve_key(parsed)
+    RbShard.save_rbs(output, File.binread(input), key, kdf_iterations: parsed[:kdf_iterations])
     puts "Packed #{input} -> #{output}"
     0
   end
@@ -137,8 +139,8 @@ module RbShardCLI
       Usage: rbshard COMMAND [options]
 
       Commands:
-        pack INPUT OUTPUT       Create a versioned .rbs container
-        unpack INPUT OUTPUT     Restore plaintext from a .rbs file
+        pack INPUT OUTPUT       Create an authenticated v2 .rbs container
+        unpack INPUT OUTPUT     Restore plaintext from v2, v1, or legacy data
         inspect FILE            Display container metadata without decrypting
         encode INPUT OUTPUT     Use the legacy raw encode codec
         decode INPUT OUTPUT     Use the legacy raw decode codec

--- a/bin/rbshard
+++ b/bin/rbshard
@@ -40,15 +40,25 @@ module RbShardCLI
   end
 
   def pack_command(argv)
-    config = { kdf_iterations: RbShard::V2_KDF_ITERATIONS }
-    options = common_io_options('Pack plaintext into a versioned .rbs container')
+    config = {
+      kdf_iterations: RbShard::V2_KDF_ITERATIONS,
+      chunk_size: RbShard::V3_DEFAULT_CHUNK_SIZE
+    }
+    options = common_io_options('Pack plaintext into a streaming authenticated .rbs container')
     key_options(options)
-    options.on('--kdf-iterations N', Integer, 'PBKDF2 iterations for new v2 archives') { |value| config[:kdf_iterations] = value }
+    options.on('--kdf-iterations N', Integer, 'PBKDF2 iterations for new v3 archives') { |value| config[:kdf_iterations] = value }
+    options.on('--chunk-size BYTES', Integer, 'Plaintext bytes per authenticated chunk') { |value| config[:chunk_size] = value }
     parsed, paths = parse(options, argv, config)
     input, output = require_paths(paths)
     key = resolve_key(parsed)
-    RbShard.save_rbs(output, File.binread(input), key, kdf_iterations: parsed[:kdf_iterations])
-    puts "Packed #{input} -> #{output}"
+    metadata = RbShard.pack_file(
+      input,
+      output,
+      key,
+      chunk_size: parsed[:chunk_size],
+      kdf_iterations: parsed[:kdf_iterations]
+    )
+    puts "Packed #{input} -> #{output} (v#{metadata[:version]}, #{metadata[:chunk_count]} chunks)"
     0
   end
 
@@ -60,9 +70,10 @@ module RbShardCLI
     parsed, paths = parse(options, argv, config)
     input, output = require_paths(paths)
     key = resolve_key(parsed)
-    plaintext = RbShard.load_rbs(input, key, allow_legacy: parsed[:allow_legacy])
-    File.binwrite(output, plaintext)
-    puts "Unpacked #{input} -> #{output}"
+    metadata = RbShard.unpack_file(input, output, key, allow_legacy: parsed[:allow_legacy])
+    version = metadata.is_a?(Hash) ? metadata[:version] : nil
+    suffix = version ? " (v#{version})" : ''
+    puts "Unpacked #{input} -> #{output}#{suffix}"
     0
   end
 
@@ -74,7 +85,7 @@ module RbShardCLI
     _config, paths = parse(options, argv)
     raise ArgumentError, 'inspect requires exactly one FILE' unless paths.length == 1
 
-    metadata = RbShard.inspect_rbs(File.binread(paths.first))
+    metadata = RbShard.inspect_rbs_file(paths.first)
     metadata.each { |key, value| puts "#{key}: #{value}" }
     0
   end
@@ -139,13 +150,17 @@ module RbShardCLI
       Usage: rbshard COMMAND [options]
 
       Commands:
-        pack INPUT OUTPUT       Create an authenticated v2 .rbs container
-        unpack INPUT OUTPUT     Restore plaintext from v2, v1, or legacy data
-        inspect FILE            Display container metadata without decrypting
+        pack INPUT OUTPUT       Stream input into an authenticated v3 .rbs container
+        unpack INPUT OUTPUT     Restore plaintext from v3, v2, v1, or legacy data
+        inspect FILE            Display container metadata without loading the file
         encode INPUT OUTPUT     Use the legacy raw encode codec
         decode INPUT OUTPUT     Use the legacy raw decode codec
         version                 Print the installed version
         help                    Show this help
+
+      Pack options:
+        --chunk-size BYTES      Plaintext bytes per independently authenticated chunk
+        --kdf-iterations N      PBKDF2 work factor for the archive
 
       Key input for encryption/decryption commands:
         --key KEY               Pass a key directly (least private)

--- a/bin/rbshard_ui
+++ b/bin/rbshard_ui
@@ -53,34 +53,39 @@ class RbShardServlet < WEBrick::HTTPServlet::AbstractServlet
       response.body = result_page('Decode', result)
     when '/encode_file'
       file = request.query['file']&.tempfile
-      key  = request.query['key'] || ''
+      key = request.query['key'] || ''
       if (err = validate_key(key))
         result = err
       elsif file.nil?
         result = 'Error: file is required'
       else
-        encoded = RbShard.encode(file.read, key)
+        archive = RbShard.pack(file.read, key)
         response.status = 200
         response['Content-Type'] = 'application/octet-stream'
         response['Content-Disposition'] = 'attachment; filename="encoded.rbs"'
-        response.body = encoded
+        response.body = archive
         return
       end
       response.content_type = 'text/html'
       response.body = result_page('Encode File', result)
     when '/decode_file'
       file = request.query['file']&.tempfile
-      key  = request.query['key'] || ''
+      key = request.query['key'] || ''
       if (err = validate_key(key))
         result = err
       elsif file.nil?
         result = 'Error: file is required'
       else
         begin
-          decoded = RbShard.decode(file.read, key)
+          raw = file.read
+          decoded = if RbShard.container?(raw)
+                      RbShard.unpack(raw, key)
+                    else
+                      RbShard.decode(raw, key)
+                    end
           response.status = 200
           response['Content-Type'] = 'application/octet-stream'
-          response['Content-Disposition'] = 'attachment; filename="decoded.txt"'
+          response['Content-Disposition'] = 'attachment; filename="decoded.bin"'
           response.body = decoded
           return
         rescue => e
@@ -101,39 +106,46 @@ class RbShardServlet < WEBrick::HTTPServlet::AbstractServlet
     <<-HTML
     <html>
       <head>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <title>RbShard UI</title>
         <style>
-          body { font-family: sans-serif; margin: 2em; }
-          textarea { width: 100%; }
-          .section { margin-bottom: 2em; }
+          :root { color-scheme: light dark; }
+          body { font-family: system-ui, sans-serif; margin: 2em auto; max-width: 900px; padding: 0 1em; }
+          textarea { width: 100%; box-sizing: border-box; }
+          input[type="text"], input[type="password"] { width: min(100%, 28rem); }
+          .section { margin-bottom: 2em; padding: 1em; border: 1px solid #7775; border-radius: 8px; }
+          .hint { opacity: 0.75; font-size: 0.9em; }
         </style>
       </head>
       <body>
         <h1>RbShard UI</h1>
+        <p class="hint">File encoding writes the versioned RBSH container format. Text encode/decode retains the legacy Base64-wrapped raw codec for compatibility.</p>
         <div class="section">
-          <h2>Encode</h2>
+          <h2>Encode Text</h2>
           <form action="/encode" method="post">
             <textarea name="data" rows="5"></textarea><br/>
-            Key: <input type="text" name="key" required/><br/>
+            Key: <input type="password" name="key" minlength="8" required/><br/>
             <input type="submit" value="Encode"/>
           </form>
-          <h3>From File</h3>
+          <h3>Pack File</h3>
           <form action="/encode_file" method="post" enctype="multipart/form-data">
-            <input type="file" name="file"/><br/>
-            Key: <input type="text" name="key" required/><br/>
-            <input type="submit" value="Encode File"/>
+            <input type="file" name="file" required/><br/>
+            Key: <input type="password" name="key" minlength="8" required/><br/>
+            <input type="submit" value="Create .rbs File"/>
           </form>
         </div>
         <div class="section">
-          <h2>Decode</h2>
+          <h2>Decode Text</h2>
           <form action="/decode" method="post">
             <textarea name="data" rows="5"></textarea><br/>
-            Key: <input type="text" name="key" required/><br/>
+            Key: <input type="password" name="key" minlength="8" required/><br/>
             <input type="submit" value="Decode"/>
           </form>
-          <h3>From File</h3>
+          <h3>Unpack File</h3>
           <form action="/decode_file" method="post" enctype="multipart/form-data">
-            <input type="file" name="file"/><br/>
-            Key: <input type="text" name="key" required/><br/>
+            <input type="file" name="file" required/><br/>
+            Key: <input type="password" name="key" minlength="8" required/><br/>
             <input type="submit" value="Decode File"/>
           </form>
         </div>
@@ -146,8 +158,9 @@ class RbShardServlet < WEBrick::HTTPServlet::AbstractServlet
     escaped = CGI.escapeHTML(result.to_s)
     <<-HTML
     <html>
+      <head><meta charset="utf-8"/><title>#{CGI.escapeHTML(action)} Result</title></head>
       <body>
-        <h1>#{action} Result</h1>
+        <h1>#{CGI.escapeHTML(action)} Result</h1>
         <textarea rows="5" cols="60" readonly>#{escaped}</textarea><br/>
         <a href="/">Back</a>
       </body>
@@ -156,7 +169,8 @@ class RbShardServlet < WEBrick::HTTPServlet::AbstractServlet
   end
 end
 
-server = WEBrick::HTTPServer.new(Port: 4567)
+server = WEBrick::HTTPServer.new(Port: Integer(ENV.fetch('PORT', '4567')), BindAddress: ENV.fetch('BIND', '127.0.0.1'))
 server.mount '/', RbShardServlet
 trap('INT') { server.shutdown }
+trap('TERM') { server.shutdown }
 server.start

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -1,16 +1,86 @@
 # RbShard Container Format
 
-This document describes the portable `.rbs` container family. New writers emit format version 2. Readers retain compatibility with version 1 and with the original headerless raw codec.
+This document describes the portable `.rbs` container family. File-oriented writers now emit streaming **RBS v3** containers. The in-memory `RbShard.pack` API continues to emit authenticated RBS v2. Readers retain compatibility with v3, v2, v1, and the original headerless raw codec.
 
 ## Goals
 
-The container layer gives RbShard files a recognizable signature, explicit versioning, deterministic payload boundaries, password-based key derivation, randomized encryption, integrity/authenticity checking, and an upgrade path independent of the public Ruby API.
+The format provides recognizable magic bytes, explicit versioning, bounded parser work, password-based key derivation, randomized encryption, integrity/authenticity checking, backward compatibility, and a path for multi-gigabyte files without loading the entire plaintext or ciphertext into memory.
 
-## Version 2 (current)
+## Version 3 — streaming file format
 
-### Byte layout
+RBS v3 divides plaintext into independently compressed, encrypted, and authenticated records. A final authenticated footer binds the ordered list of chunk tags and aggregate counts.
 
-All offsets are measured from the beginning of the file.
+### File header
+
+| Offset | Length | Name | Encoding |
+| ---: | ---: | --- | --- |
+| 0 | 4 | magic | ASCII `RBSH` |
+| 4 | 1 | version | unsigned byte, value `3` |
+| 5 | 4 | KDF iterations | unsigned 32-bit little-endian |
+| 9 | 4 | chunk size | unsigned 32-bit little-endian |
+| 13 | 16 | salt | random bytes |
+
+The v3 header is 29 bytes.
+
+The password/key is expanded with PBKDF2-HMAC-SHA256 into 64 bytes. The first 32 bytes are the Twofish encryption key and the final 32 bytes are the HMAC authentication key. The default KDF work factor remains 200,000 iterations.
+
+### Chunk record
+
+Each non-empty plaintext chunk is represented as:
+
+| Length | Name | Encoding |
+| ---: | --- | --- |
+| 4 | marker | ASCII `CHNK` |
+| 4 | chunk index | unsigned 32-bit little-endian |
+| 4 | plaintext length | unsigned 32-bit little-endian |
+| 4 | ciphertext length | unsigned 32-bit little-endian |
+| 16 | IV | random bytes |
+| N | ciphertext | LZW-compressed plaintext encrypted with Twofish-CBC + PKCS#7 |
+| 32 | chunk tag | HMAC-SHA256 |
+
+The per-chunk tag is:
+
+```text
+HMAC-SHA256(authentication_key,
+            complete_v3_header || chunk_record_header || ciphertext)
+```
+
+Readers MUST validate the chunk index and length bounds, read the complete ciphertext/tag, and verify the chunk tag before decrypting or decompressing that record.
+
+Chunk IVs are generated independently. Chunk indexes begin at zero and increase by exactly one.
+
+### Footer
+
+After the last chunk, writers emit:
+
+| Length | Name | Encoding |
+| ---: | --- | --- |
+| 4 | marker | ASCII `END!` |
+| 4 | chunk count | unsigned 32-bit little-endian |
+| 8 | total plaintext bytes | unsigned 64-bit little-endian |
+| 32 | final tag | HMAC-SHA256 |
+
+The final tag is produced incrementally over:
+
+```text
+complete_v3_header ||
+chunk_0_tag || chunk_1_tag || ... || chunk_n_tag ||
+footer_marker || chunk_count || total_plaintext_bytes
+```
+
+This footer detects missing/reordered records and authenticates the aggregate chunk count and total plaintext length. Readers MUST reject trailing bytes after the footer.
+
+### Streaming and commit semantics
+
+The library's `pack_stream` / `unpack_stream` methods operate on IO objects with memory bounded to approximately one working chunk plus its compressed/ciphertext representations.
+
+The file-oriented `unpack_file` helper writes v3 plaintext to a temporary file and atomically renames it to the requested destination only after the final footer authenticates. A wrong password, corrupted chunk, truncated archive, or invalid footer therefore does not replace the existing destination with partially verified plaintext.
+
+The default plaintext chunk size is 1 MiB. Current readers accept chunk sizes from 1 KiB through 64 MiB.
+
+## Version 2 — authenticated in-memory format
+
+RBS v2 remains supported and is still emitted by `RbShard.pack` / `RbShard.save_rbs` for compatibility with the in-memory API.
 
 | Offset | Length | Name | Encoding |
 | ---: | ---: | --- | --- |
@@ -23,57 +93,11 @@ All offsets are measured from the beginning of the file.
 | 45 | N | encrypted payload | opaque bytes |
 | 45 + N | 32 | authentication tag | HMAC-SHA256 |
 
-The total file size MUST be `77 + N` bytes.
+The total file size is `77 + N` bytes. V2 compresses the complete plaintext with LZW, encrypts it with Twofish-CBC + PKCS#7, and authenticates `complete_v2_header || ciphertext` with HMAC-SHA256. Readers verify the tag before decryption.
 
-### Key derivation
+V2 is authenticated but requires the complete payload in memory; v3 is preferred for file workflows.
 
-The caller-supplied key/password is processed using PBKDF2-HMAC-SHA256:
-
-```text
-PBKDF2-HMAC-SHA256(
-  password = caller supplied key bytes,
-  salt = 16-byte container salt,
-  iterations = header iteration count,
-  output length = 64 bytes
-)
-```
-
-The first 32 derived bytes are the Twofish encryption key. The final 32 bytes are the HMAC authentication key.
-
-The current writer default is 200,000 PBKDF2 iterations. Readers accept bounded iteration counts so a malicious header cannot request unbounded KDF work.
-
-### Encryption pipeline
-
-```text
-plaintext
-   |
-   v
-LZW compression
-   |
-   v
-Twofish-CBC + PKCS#7 padding
-32-byte derived encryption key
-16-byte random IV
-   |
-   v
-ciphertext
-```
-
-The 16-byte IV is stored in the authenticated header. Repacking identical plaintext with the same password SHOULD produce different container bytes because both the salt and IV are randomly generated.
-
-### Authentication
-
-Version 2 uses encrypt-then-MAC. The tag is:
-
-```text
-HMAC-SHA256(authentication_key, complete_v2_header || ciphertext)
-```
-
-Readers MUST verify the tag before attempting CBC decryption or decompression. An authentication failure should be reported without attempting to distinguish a wrong password from modified/corrupted input.
-
-## Version 1 (read compatibility)
-
-Version 1 was the first self-identifying RbShard container design.
+## Version 1 — read compatibility
 
 | Offset | Length | Name | Encoding |
 | ---: | ---: | --- | --- |
@@ -83,15 +107,11 @@ Version 1 was the first self-identifying RbShard container design.
 | 9 | N | encrypted payload | legacy raw codec bytes |
 | 9 + N | 32 | digest | SHA-256 of plaintext |
 
-The total file size is `41 + N` bytes.
-
-Version 1 detects accidental corruption and generally detects wrong-key output, but its digest is unkeyed and therefore it is **not an authenticated format**. New writers MUST prefer version 2.
+Version 1 uses an unkeyed digest and therefore is **not an authenticated format**. It remains read-only compatibility data.
 
 ## Headerless legacy payloads
 
-Files from the original implementation contain only the result of the legacy `RbShard.encode` pipeline and therefore do not start with `RBSH`.
-
-`RbShard.load_rbs` can read these by default for backward compatibility. Applications that do not need old files can pass `allow_legacy: false` to reject them. The raw `encode` / `decode` API is preserved specifically for compatibility and should not be selected for new file formats.
+Original files contain only the result of the historical `RbShard.encode` pipeline and do not start with `RBSH`. `RbShard.load_rbs` / `unpack_file` can read these by default. Callers may set `allow_legacy: false` to reject them.
 
 ## Compatibility matrix
 
@@ -99,24 +119,16 @@ Files from the original implementation contain only the result of the legacy `Rb
 | --- | --- | --- |
 | Headerless legacy | supported by default | raw API only |
 | RBS v1 | supported | no |
-| RBS v2 | supported | yes |
-| Unknown future version | rejected | n/a |
+| RBS v2 | supported | `pack` / `save_rbs` |
+| RBS v3 | supported | `pack_stream` / `pack_file` / CLI `pack` |
+| Unknown future version | rejected for decoding | n/a |
 
 ## Parser requirements
 
-Implementations should reject:
+Implementations should reject malformed/truncated headers, unsupported versions, unreasonable KDF or chunk-size parameters, invalid record markers, non-sequential chunk indexes, impossible record lengths, authentication-tag mismatches before decryption, malformed compressed streams, inconsistent footer counts/lengths, truncated footers, and trailing bytes after a valid footer.
 
-* truncated headers;
-* unknown magic values;
-* unsupported versions when decoding;
-* files whose actual size differs from the declared payload length;
-* v2 KDF iteration counts outside the implementation's accepted safety bounds;
-* v2 authentication-tag mismatches before decryption;
-* failed decryption; and
-* malformed compressed streams.
-
-Parsers should treat all payload, salt, IV, tag, and key material as binary and should not depend on the process default text encoding.
+All payload, salt, IV, tag, and key material is binary. Implementations should not depend on the process default text encoding.
 
 ## Security boundary
 
-Version 2 materially improves the format by adding randomized CBC encryption, password-based key derivation, independent encryption/authentication keys, and encrypt-then-HMAC authentication. It remains an experimental project built on a pure-Ruby Twofish dependency and has not received a dedicated cryptographic audit. Applications with high-value secrets should prefer mature, audited storage formats and libraries.
+V2 and v3 use randomized CBC encryption, PBKDF2-HMAC-SHA256, independently derived encryption/authentication keys, and encrypt-then-HMAC authentication. V3 additionally constrains memory use and authenticates each record before plaintext release. RbShard remains an experimental project built on a pure-Ruby Twofish dependency and has not received an independent cryptographic audit; high-value or regulated secrets should still prefer mature, audited encryption formats and libraries.

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -1,28 +1,48 @@
 # RbShard Container Format
 
-This document describes the portable `.rbs` container introduced as format version 1.
+This document describes the portable `.rbs` container family. New writers emit format version 2. Readers retain compatibility with version 1 and with the original headerless raw codec.
 
 ## Goals
 
-The container layer gives RbShard files a recognizable signature, explicit versioning, deterministic payload boundaries, and post-decryption integrity checking while preserving the original `RbShard.encode` / `RbShard.decode` codec for compatibility.
+The container layer gives RbShard files a recognizable signature, explicit versioning, deterministic payload boundaries, password-based key derivation, randomized encryption, integrity/authenticity checking, and an upgrade path independent of the public Ruby API.
 
-## Byte layout
+## Version 2 (current)
+
+### Byte layout
 
 All offsets are measured from the beginning of the file.
 
 | Offset | Length | Name | Encoding |
 | ---: | ---: | --- | --- |
 | 0 | 4 | magic | ASCII `RBSH` |
-| 4 | 1 | version | unsigned byte |
-| 5 | 4 | encrypted length | unsigned 32-bit little-endian |
-| 9 | N | encrypted payload | opaque bytes |
-| 9 + N | 32 | digest | SHA-256 bytes |
+| 4 | 1 | version | unsigned byte, value `2` |
+| 5 | 4 | KDF iterations | unsigned 32-bit little-endian |
+| 9 | 16 | salt | random bytes |
+| 25 | 16 | IV | random bytes |
+| 41 | 4 | encrypted length | unsigned 32-bit little-endian |
+| 45 | N | encrypted payload | opaque bytes |
+| 45 + N | 32 | authentication tag | HMAC-SHA256 |
 
-The total file size MUST be `41 + N` bytes for version 1.
+The total file size MUST be `77 + N` bytes.
 
-## Payload processing
+### Key derivation
 
-Writers perform the following logical pipeline:
+The caller-supplied key/password is processed using PBKDF2-HMAC-SHA256:
+
+```text
+PBKDF2-HMAC-SHA256(
+  password = caller supplied key bytes,
+  salt = 16-byte container salt,
+  iterations = header iteration count,
+  output length = 64 bytes
+)
+```
+
+The first 32 derived bytes are the Twofish encryption key. The final 32 bytes are the HMAC authentication key.
+
+The current writer default is 200,000 PBKDF2 iterations. Readers accept bounded iteration counts so a malicious header cannot request unbounded KDF work.
+
+### Encryption pipeline
 
 ```text
 plaintext
@@ -31,25 +51,56 @@ plaintext
 LZW compression
    |
    v
-Twofish encryption
+Twofish-CBC + PKCS#7 padding
+32-byte derived encryption key
+16-byte random IV
    |
    v
-encrypted payload
+ciphertext
 ```
 
-The trailing digest is `SHA256(plaintext)`.
+The 16-byte IV is stored in the authenticated header. Repacking identical plaintext with the same password SHOULD produce different container bytes because both the salt and IV are randomly generated.
 
-Readers validate the magic, version, declared payload length, and total container size before attempting to decode the payload. After decryption and decompression, readers compare `SHA256(plaintext)` with the stored digest.
+### Authentication
 
-## Compatibility
+Version 2 uses encrypt-then-MAC. The tag is:
 
-Files created by earlier releases contain only the encrypted LZW payload and therefore do not start with `RBSH`. `RbShard.load_rbs` treats these as legacy payloads when `allow_legacy` is true. Applications that require only the new container can set `allow_legacy: false`.
+```text
+HMAC-SHA256(authentication_key, complete_v2_header || ciphertext)
+```
 
-## Security properties and limitations
+Readers MUST verify the tag before attempting CBC decryption or decompression. An authentication failure should be reported without attempting to distinguish a wrong password from modified/corrupted input.
 
-Version 1 detects accidental corruption and normally detects an incorrect key after decryption. The digest is not keyed, so version 1 MUST NOT be described as an authenticated-encryption format and is not designed to protect against deliberate ciphertext modification by an active attacker.
+## Version 1 (read compatibility)
 
-A future format version should use a standard authenticated-encryption or encrypt-then-MAC construction, include any required nonce/salt/KDF parameters in the authenticated header, and publish interoperable test vectors.
+Version 1 was the first self-identifying RbShard container design.
+
+| Offset | Length | Name | Encoding |
+| ---: | ---: | --- | --- |
+| 0 | 4 | magic | ASCII `RBSH` |
+| 4 | 1 | version | unsigned byte, value `1` |
+| 5 | 4 | encrypted length | unsigned 32-bit little-endian |
+| 9 | N | encrypted payload | legacy raw codec bytes |
+| 9 + N | 32 | digest | SHA-256 of plaintext |
+
+The total file size is `41 + N` bytes.
+
+Version 1 detects accidental corruption and generally detects wrong-key output, but its digest is unkeyed and therefore it is **not an authenticated format**. New writers MUST prefer version 2.
+
+## Headerless legacy payloads
+
+Files from the original implementation contain only the result of the legacy `RbShard.encode` pipeline and therefore do not start with `RBSH`.
+
+`RbShard.load_rbs` can read these by default for backward compatibility. Applications that do not need old files can pass `allow_legacy: false` to reject them. The raw `encode` / `decode` API is preserved specifically for compatibility and should not be selected for new file formats.
+
+## Compatibility matrix
+
+| Input | Current reader | Current writer |
+| --- | --- | --- |
+| Headerless legacy | supported by default | raw API only |
+| RBS v1 | supported | no |
+| RBS v2 | supported | yes |
+| Unknown future version | rejected | n/a |
 
 ## Parser requirements
 
@@ -57,10 +108,15 @@ Implementations should reject:
 
 * truncated headers;
 * unknown magic values;
-* unsupported versions;
+* unsupported versions when decoding;
 * files whose actual size differs from the declared payload length;
-* malformed compressed streams;
+* v2 KDF iteration counts outside the implementation's accepted safety bounds;
+* v2 authentication-tag mismatches before decryption;
 * failed decryption; and
-* plaintext whose digest does not match the stored digest.
+* malformed compressed streams.
 
-Parsers should treat all payload data as binary and should not depend on the process default text encoding.
+Parsers should treat all payload, salt, IV, tag, and key material as binary and should not depend on the process default text encoding.
+
+## Security boundary
+
+Version 2 materially improves the format by adding randomized CBC encryption, password-based key derivation, independent encryption/authentication keys, and encrypt-then-HMAC authentication. It remains an experimental project built on a pure-Ruby Twofish dependency and has not received a dedicated cryptographic audit. Applications with high-value secrets should prefer mature, audited storage formats and libraries.

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -1,0 +1,66 @@
+# RbShard Container Format
+
+This document describes the portable `.rbs` container introduced as format version 1.
+
+## Goals
+
+The container layer gives RbShard files a recognizable signature, explicit versioning, deterministic payload boundaries, and post-decryption integrity checking while preserving the original `RbShard.encode` / `RbShard.decode` codec for compatibility.
+
+## Byte layout
+
+All offsets are measured from the beginning of the file.
+
+| Offset | Length | Name | Encoding |
+| ---: | ---: | --- | --- |
+| 0 | 4 | magic | ASCII `RBSH` |
+| 4 | 1 | version | unsigned byte |
+| 5 | 4 | encrypted length | unsigned 32-bit little-endian |
+| 9 | N | encrypted payload | opaque bytes |
+| 9 + N | 32 | digest | SHA-256 bytes |
+
+The total file size MUST be `41 + N` bytes for version 1.
+
+## Payload processing
+
+Writers perform the following logical pipeline:
+
+```text
+plaintext
+   |
+   v
+LZW compression
+   |
+   v
+Twofish encryption
+   |
+   v
+encrypted payload
+```
+
+The trailing digest is `SHA256(plaintext)`.
+
+Readers validate the magic, version, declared payload length, and total container size before attempting to decode the payload. After decryption and decompression, readers compare `SHA256(plaintext)` with the stored digest.
+
+## Compatibility
+
+Files created by earlier releases contain only the encrypted LZW payload and therefore do not start with `RBSH`. `RbShard.load_rbs` treats these as legacy payloads when `allow_legacy` is true. Applications that require only the new container can set `allow_legacy: false`.
+
+## Security properties and limitations
+
+Version 1 detects accidental corruption and normally detects an incorrect key after decryption. The digest is not keyed, so version 1 MUST NOT be described as an authenticated-encryption format and is not designed to protect against deliberate ciphertext modification by an active attacker.
+
+A future format version should use a standard authenticated-encryption or encrypt-then-MAC construction, include any required nonce/salt/KDF parameters in the authenticated header, and publish interoperable test vectors.
+
+## Parser requirements
+
+Implementations should reject:
+
+* truncated headers;
+* unknown magic values;
+* unsupported versions;
+* files whose actual size differs from the declared payload length;
+* malformed compressed streams;
+* failed decryption; and
+* plaintext whose digest does not match the stored digest.
+
+Parsers should treat all payload data as binary and should not depend on the process default text encoding.

--- a/lib/rbshard.rb
+++ b/lib/rbshard.rb
@@ -1,12 +1,22 @@
 require 'digest'
+require 'openssl'
+require 'securerandom'
 require 'twofish'
 require_relative 'rbshard/version'
 
 module RbShard
   MAGIC = "RBSH".b.freeze
-  FORMAT_VERSION = 1
-  HEADER_SIZE = 9
-  DIGEST_SIZE = 32
+  FORMAT_VERSION = 2
+
+  V1_HEADER_SIZE = 9
+  V1_DIGEST_SIZE = 32
+
+  V2_SALT_SIZE = 16
+  V2_IV_SIZE = 16
+  V2_TAG_SIZE = 32
+  V2_HEADER_SIZE = 45
+  V2_KDF_ITERATIONS = 200_000
+  V2_DERIVED_KEY_SIZE = 64
 
   class Error < StandardError; end
   class FormatError < Error; end
@@ -71,14 +81,16 @@ module RbShard
     end
   end
 
+  # Legacy raw encryption API. This intentionally preserves the historical
+  # default Twofish mode so existing encoded payloads remain decodable.
   def self.encrypt(data, key)
-    validate_key!(key)
+    validate_legacy_key!(key)
     cipher = Twofish.new(key, padding: Twofish::Padding::PKCS7)
     cipher.encrypt(data.to_s.b)
   end
 
   def self.decrypt(data, key)
-    validate_key!(key)
+    validate_legacy_key!(key)
     cipher = Twofish.new(key, padding: Twofish::Padding::PKCS7)
     cipher.decrypt(data.to_s.b)
   rescue StandardError => e
@@ -94,47 +106,49 @@ module RbShard
     LZW.decompress(decrypt(data, key))
   end
 
-  # Versioned .rbs container:
-  # magic(4) + version(1) + encrypted_length(4 LE) + encrypted_payload + sha256(32)
-  # The digest covers the original plaintext and provides deterministic detection
-  # of corruption or an incorrect key after decryption.
-  def self.pack(data, key)
+  # Current v2 container. Password/key material is expanded with PBKDF2-HMAC-
+  # SHA256 into independent encryption and authentication keys. The compressed
+  # payload is encrypted with Twofish-CBC using a random IV, then authenticated
+  # with HMAC-SHA256 over the complete header and ciphertext.
+  def self.pack(data, key, kdf_iterations: V2_KDF_ITERATIONS)
+    validate_password!(key)
+    validate_iterations!(kdf_iterations)
+
     plaintext = data.to_s.b
-    encrypted = encode(plaintext, key)
-    header = MAGIC + [FORMAT_VERSION, encrypted.bytesize].pack('CL<')
-    header + encrypted + Digest::SHA256.digest(plaintext)
+    compressed = LZW.compress(plaintext)
+    salt = SecureRandom.random_bytes(V2_SALT_SIZE)
+    iv = SecureRandom.random_bytes(V2_IV_SIZE)
+    encryption_key, authentication_key = derive_v2_keys(key, salt, kdf_iterations)
+    encrypted = encrypt_cbc(compressed, encryption_key, iv)
+
+    header = MAGIC +
+             [FORMAT_VERSION, kdf_iterations].pack('CL<') +
+             salt + iv +
+             [encrypted.bytesize].pack('L<')
+    tag = OpenSSL::HMAC.digest('SHA256', authentication_key, header + encrypted)
+    header + encrypted + tag
   end
 
   def self.unpack(container, key)
     bytes = container.to_s.b
-    raise FormatError, 'File is too small to be an RbShard container' if bytes.bytesize < HEADER_SIZE + DIGEST_SIZE
+    raise FormatError, 'File is too small to be an RbShard container' if bytes.bytesize < 5
     raise FormatError, 'Invalid RbShard magic header' unless bytes.start_with?(MAGIC)
 
-    version, encrypted_length = bytes.byteslice(MAGIC.bytesize, 5).unpack('CL<')
-    raise FormatError, "Unsupported RbShard format version: #{version}" unless version == FORMAT_VERSION
-
-    expected_size = HEADER_SIZE + encrypted_length + DIGEST_SIZE
-    raise FormatError, 'RbShard container length does not match its header' unless bytes.bytesize == expected_size
-
-    encrypted = bytes.byteslice(HEADER_SIZE, encrypted_length)
-    expected_digest = bytes.byteslice(HEADER_SIZE + encrypted_length, DIGEST_SIZE)
-    plaintext = decode(encrypted, key)
-    actual_digest = Digest::SHA256.digest(plaintext)
-    raise IntegrityError, 'Integrity check failed; the key may be wrong or the file may be corrupted' unless secure_compare(actual_digest, expected_digest)
-
-    plaintext
-  rescue IntegrityError, FormatError
-    raise
-  rescue StandardError => e
-    raise IntegrityError, "Unable to decode RbShard container: #{e.message}"
+    version = bytes.getbyte(MAGIC.bytesize)
+    case version
+    when 1 then unpack_v1(bytes, key)
+    when 2 then unpack_v2(bytes, key)
+    else
+      raise FormatError, "Unsupported RbShard format version: #{version}"
+    end
   end
 
   def self.container?(data)
     data.to_s.b.start_with?(MAGIC)
   end
 
-  def self.save_rbs(path, data, key)
-    File.binwrite(path, pack(data, key))
+  def self.save_rbs(path, data, key, kdf_iterations: V2_KDF_ITERATIONS)
+    File.binwrite(path, pack(data, key, kdf_iterations: kdf_iterations))
   end
 
   def self.load_rbs(path, key, allow_legacy: true)
@@ -148,22 +162,142 @@ module RbShard
   def self.inspect_rbs(data)
     bytes = data.to_s.b
     return { format: :legacy, version: nil, payload_bytes: bytes.bytesize } unless container?(bytes)
-    raise FormatError, 'File is too small to contain a complete header' if bytes.bytesize < HEADER_SIZE
+    raise FormatError, 'File is too small to contain a complete header' if bytes.bytesize < 5
+
+    version = bytes.getbyte(MAGIC.bytesize)
+    case version
+    when 1
+      inspect_v1(bytes)
+    when 2
+      inspect_v2(bytes)
+    else
+      { format: :container, version: version, supported: false, total_bytes: bytes.bytesize }
+    end
+  end
+
+  def self.unpack_v1(bytes, key)
+    raise FormatError, 'File is too small to be an RbShard v1 container' if bytes.bytesize < V1_HEADER_SIZE + V1_DIGEST_SIZE
 
     version, encrypted_length = bytes.byteslice(MAGIC.bytesize, 5).unpack('CL<')
+    raise FormatError, "Unsupported RbShard format version: #{version}" unless version == 1
+
+    expected_size = V1_HEADER_SIZE + encrypted_length + V1_DIGEST_SIZE
+    raise FormatError, 'RbShard v1 container length does not match its header' unless bytes.bytesize == expected_size
+
+    encrypted = bytes.byteslice(V1_HEADER_SIZE, encrypted_length)
+    expected_digest = bytes.byteslice(V1_HEADER_SIZE + encrypted_length, V1_DIGEST_SIZE)
+    plaintext = decode(encrypted, key)
+    actual_digest = Digest::SHA256.digest(plaintext)
+    raise IntegrityError, 'V1 integrity check failed; the key may be wrong or the file may be corrupted' unless secure_compare(actual_digest, expected_digest)
+
+    plaintext
+  rescue IntegrityError, FormatError
+    raise
+  rescue StandardError => e
+    raise IntegrityError, "Unable to decode RbShard v1 container: #{e.message}"
+  end
+  private_class_method :unpack_v1
+
+  def self.unpack_v2(bytes, key)
+    validate_password!(key)
+    raise FormatError, 'File is too small to be an RbShard v2 container' if bytes.bytesize < V2_HEADER_SIZE + V2_TAG_SIZE
+
+    version, kdf_iterations = bytes.byteslice(MAGIC.bytesize, 5).unpack('CL<')
+    raise FormatError, "Unsupported RbShard format version: #{version}" unless version == 2
+    validate_iterations!(kdf_iterations)
+
+    salt = bytes.byteslice(9, V2_SALT_SIZE)
+    iv = bytes.byteslice(25, V2_IV_SIZE)
+    encrypted_length = bytes.byteslice(41, 4).unpack1('L<')
+    expected_size = V2_HEADER_SIZE + encrypted_length + V2_TAG_SIZE
+    raise FormatError, 'RbShard v2 container length does not match its header' unless bytes.bytesize == expected_size
+
+    header = bytes.byteslice(0, V2_HEADER_SIZE)
+    encrypted = bytes.byteslice(V2_HEADER_SIZE, encrypted_length)
+    expected_tag = bytes.byteslice(V2_HEADER_SIZE + encrypted_length, V2_TAG_SIZE)
+    encryption_key, authentication_key = derive_v2_keys(key, salt, kdf_iterations)
+    actual_tag = OpenSSL::HMAC.digest('SHA256', authentication_key, header + encrypted)
+    raise IntegrityError, 'Authentication failed; the key may be wrong or the file may be corrupted' unless secure_compare(actual_tag, expected_tag)
+
+    compressed = decrypt_cbc(encrypted, encryption_key, iv)
+    LZW.decompress(compressed)
+  rescue IntegrityError, FormatError
+    raise
+  rescue StandardError => e
+    raise IntegrityError, "Unable to decode RbShard v2 container: #{e.message}"
+  end
+  private_class_method :unpack_v2
+
+  def self.inspect_v1(bytes)
+    raise FormatError, 'File is too small to contain a complete v1 header' if bytes.bytesize < V1_HEADER_SIZE
+    _version, encrypted_length = bytes.byteslice(MAGIC.bytesize, 5).unpack('CL<')
     {
       format: :container,
-      version: version,
+      version: 1,
+      authenticated: false,
       payload_bytes: encrypted_length,
       total_bytes: bytes.bytesize
     }
   end
+  private_class_method :inspect_v1
 
-  def self.validate_key!(key)
+  def self.inspect_v2(bytes)
+    raise FormatError, 'File is too small to contain a complete v2 header' if bytes.bytesize < V2_HEADER_SIZE
+    _version, kdf_iterations = bytes.byteslice(MAGIC.bytesize, 5).unpack('CL<')
+    encrypted_length = bytes.byteslice(41, 4).unpack1('L<')
+    {
+      format: :container,
+      version: 2,
+      authenticated: true,
+      kdf: :'pbkdf2-hmac-sha256',
+      kdf_iterations: kdf_iterations,
+      cipher: :'twofish-cbc',
+      payload_bytes: encrypted_length,
+      total_bytes: bytes.bytesize
+    }
+  end
+  private_class_method :inspect_v2
+
+  def self.derive_v2_keys(password, salt, iterations)
+    material = OpenSSL::PKCS5.pbkdf2_hmac(password.to_s.b, salt, iterations, V2_DERIVED_KEY_SIZE, 'SHA256')
+    [material.byteslice(0, 32), material.byteslice(32, 32)]
+  end
+  private_class_method :derive_v2_keys
+
+  def self.encrypt_cbc(data, key, iv)
+    cipher = Twofish.new(key, mode: :cbc, padding: Twofish::Padding::PKCS7)
+    cipher.iv = iv
+    cipher.encrypt(data.to_s.b)
+  end
+  private_class_method :encrypt_cbc
+
+  def self.decrypt_cbc(data, key, iv)
+    cipher = Twofish.new(key, mode: :cbc, padding: Twofish::Padding::PKCS7)
+    cipher.iv = iv
+    cipher.decrypt(data.to_s.b)
+  end
+  private_class_method :decrypt_cbc
+
+  def self.validate_password!(key)
     raise ArgumentError, 'Key is required' if key.nil? || key.empty?
     key
   end
-  private_class_method :validate_key!
+  private_class_method :validate_password!
+
+  def self.validate_legacy_key!(key)
+    validate_password!(key)
+    raise ArgumentError, 'Legacy Twofish keys must be 32 bytes or fewer' if key.to_s.b.bytesize > 32
+    key
+  end
+  private_class_method :validate_legacy_key!
+
+  def self.validate_iterations!(iterations)
+    unless iterations.is_a?(Integer) && iterations.between?(10_000, 10_000_000)
+      raise FormatError, 'PBKDF2 iteration count is outside the accepted range'
+    end
+    iterations
+  end
+  private_class_method :validate_iterations!
 
   def self.secure_compare(left, right)
     return false unless left.bytesize == right.bytesize

--- a/lib/rbshard.rb
+++ b/lib/rbshard.rb
@@ -106,10 +106,8 @@ module RbShard
     LZW.decompress(decrypt(data, key))
   end
 
-  # Current v2 container. Password/key material is expanded with PBKDF2-HMAC-
-  # SHA256 into independent encryption and authentication keys. The compressed
-  # payload is encrypted with Twofish-CBC using a random IV, then authenticated
-  # with HMAC-SHA256 over the complete header and ciphertext.
+  # In-memory authenticated v2 container. File-oriented callers should prefer
+  # pack_file/unpack_file, which use streaming RBS v3 for bounded memory use.
   def self.pack(data, key, kdf_iterations: V2_KDF_ITERATIONS)
     validate_password!(key)
     validate_iterations!(kdf_iterations)
@@ -138,6 +136,7 @@ module RbShard
     case version
     when 1 then unpack_v1(bytes, key)
     when 2 then unpack_v2(bytes, key)
+    when 3 then unpack_v3_bytes(bytes, key)
     else
       raise FormatError, "Unsupported RbShard format version: #{version}"
     end
@@ -147,6 +146,8 @@ module RbShard
     data.to_s.b.start_with?(MAGIC)
   end
 
+  # Retained as an in-memory v2 helper for API compatibility. For large files,
+  # use pack_file so the input is never loaded in full.
   def self.save_rbs(path, data, key, kdf_iterations: V2_KDF_ITERATIONS)
     File.binwrite(path, pack(data, key, kdf_iterations: kdf_iterations))
   end
@@ -170,6 +171,8 @@ module RbShard
       inspect_v1(bytes)
     when 2
       inspect_v2(bytes)
+    when 3
+      inspect_v3_bytes(bytes)
     else
       { format: :container, version: version, supported: false, total_bytes: bytes.bytesize }
     end
@@ -248,6 +251,7 @@ module RbShard
     {
       format: :container,
       version: 2,
+      streaming: false,
       authenticated: true,
       kdf: :'pbkdf2-hmac-sha256',
       kdf_iterations: kdf_iterations,
@@ -305,3 +309,5 @@ module RbShard
   end
   private_class_method :secure_compare
 end
+
+require_relative 'rbshard/stream'

--- a/lib/rbshard.rb
+++ b/lib/rbshard.rb
@@ -1,40 +1,70 @@
+require 'digest'
 require 'twofish'
 require_relative 'rbshard/version'
 
 module RbShard
+  MAGIC = "RBSH".b.freeze
+  FORMAT_VERSION = 1
+  HEADER_SIZE = 9
+  DIGEST_SIZE = 32
+
+  class Error < StandardError; end
+  class FormatError < Error; end
+  class IntegrityError < Error; end
+
   class LZW
+    MAX_CODE = 0xffff
+
     def self.compress(input)
+      input = input.to_s.b
+      return ''.b if input.empty?
+
       dict_size = 256
-      dictionary = Hash[Array(0..255).map { |i| [i.chr, i] }]
-      w = ''
+      dictionary = Hash[Array(0..255).map { |i| [i.chr(Encoding::BINARY), i] }]
+      w = ''.b
       result = []
-      input.each_char do |c|
+
+      input.each_byte do |byte|
+        c = byte.chr(Encoding::BINARY)
         wc = w + c
         if dictionary.key?(wc)
           w = wc
         else
-          result << dictionary[w]
-          dictionary[wc] = dict_size
-          dict_size += 1
+          result << dictionary.fetch(w)
+          if dict_size <= MAX_CODE
+            dictionary[wc] = dict_size
+            dict_size += 1
+          end
           w = c
         end
       end
-      result << dictionary[w] unless w.empty?
-      result.pack('S*')
+
+      result << dictionary.fetch(w) unless w.empty?
+      result.pack('S<*')
     end
 
     def self.decompress(compressed)
-      compressed_codes = compressed.unpack('S*')
+      compressed = compressed.to_s.b
+      return ''.b if compressed.empty?
+      raise FormatError, 'Compressed payload has an invalid length' if compressed.bytesize.odd?
+
+      compressed_codes = compressed.unpack('S<*')
       dict_size = 256
-      dictionary = Hash[Array(0..255).map { |i| [i, i.chr] }]
-      w = dictionary[compressed_codes.shift]
+      dictionary = Hash[Array(0..255).map { |i| [i, i.chr(Encoding::BINARY)] }]
+      first = compressed_codes.shift
+      w = dictionary[first]
+      raise FormatError, "Invalid initial LZW code: #{first}" unless w
+
       result = w.dup
-      compressed_codes.each do |k|
-        entry = dictionary[k] || (k == dict_size ? w + w[0] : nil)
-        raise "Bad compressed k: #{k}" unless entry
+      compressed_codes.each do |code|
+        entry = dictionary[code] || (code == dict_size ? w + w.byteslice(0, 1) : nil)
+        raise FormatError, "Invalid LZW code: #{code}" unless entry
+
         result << entry
-        dictionary[dict_size] = w + entry[0]
-        dict_size += 1
+        if dict_size <= MAX_CODE
+          dictionary[dict_size] = w + entry.byteslice(0, 1)
+          dict_size += 1
+        end
         w = entry
       end
       result
@@ -42,15 +72,20 @@ module RbShard
   end
 
   def self.encrypt(data, key)
+    validate_key!(key)
     cipher = Twofish.new(key, padding: Twofish::Padding::PKCS7)
-    cipher.encrypt(data)
+    cipher.encrypt(data.to_s.b)
   end
 
   def self.decrypt(data, key)
+    validate_key!(key)
     cipher = Twofish.new(key, padding: Twofish::Padding::PKCS7)
-    cipher.decrypt(data)
+    cipher.decrypt(data.to_s.b)
+  rescue StandardError => e
+    raise IntegrityError, "Unable to decrypt payload: #{e.message}"
   end
 
+  # Legacy raw codec retained for API compatibility.
   def self.encode(data, key)
     encrypt(LZW.compress(data), key)
   end
@@ -59,11 +94,80 @@ module RbShard
     LZW.decompress(decrypt(data, key))
   end
 
-  def self.save_rbs(path, data, key)
-    File.binwrite(path, encode(data, key))
+  # Versioned .rbs container:
+  # magic(4) + version(1) + encrypted_length(4 LE) + encrypted_payload + sha256(32)
+  # The digest covers the original plaintext and provides deterministic detection
+  # of corruption or an incorrect key after decryption.
+  def self.pack(data, key)
+    plaintext = data.to_s.b
+    encrypted = encode(plaintext, key)
+    header = MAGIC + [FORMAT_VERSION, encrypted.bytesize].pack('CL<')
+    header + encrypted + Digest::SHA256.digest(plaintext)
   end
 
-  def self.load_rbs(path, key)
-    decode(File.binread(path), key)
+  def self.unpack(container, key)
+    bytes = container.to_s.b
+    raise FormatError, 'File is too small to be an RbShard container' if bytes.bytesize < HEADER_SIZE + DIGEST_SIZE
+    raise FormatError, 'Invalid RbShard magic header' unless bytes.start_with?(MAGIC)
+
+    version, encrypted_length = bytes.byteslice(MAGIC.bytesize, 5).unpack('CL<')
+    raise FormatError, "Unsupported RbShard format version: #{version}" unless version == FORMAT_VERSION
+
+    expected_size = HEADER_SIZE + encrypted_length + DIGEST_SIZE
+    raise FormatError, 'RbShard container length does not match its header' unless bytes.bytesize == expected_size
+
+    encrypted = bytes.byteslice(HEADER_SIZE, encrypted_length)
+    expected_digest = bytes.byteslice(HEADER_SIZE + encrypted_length, DIGEST_SIZE)
+    plaintext = decode(encrypted, key)
+    actual_digest = Digest::SHA256.digest(plaintext)
+    raise IntegrityError, 'Integrity check failed; the key may be wrong or the file may be corrupted' unless secure_compare(actual_digest, expected_digest)
+
+    plaintext
+  rescue IntegrityError, FormatError
+    raise
+  rescue StandardError => e
+    raise IntegrityError, "Unable to decode RbShard container: #{e.message}"
   end
+
+  def self.container?(data)
+    data.to_s.b.start_with?(MAGIC)
+  end
+
+  def self.save_rbs(path, data, key)
+    File.binwrite(path, pack(data, key))
+  end
+
+  def self.load_rbs(path, key, allow_legacy: true)
+    data = File.binread(path)
+    return unpack(data, key) if container?(data)
+    return decode(data, key) if allow_legacy
+
+    raise FormatError, 'Legacy headerless RbShard payload rejected'
+  end
+
+  def self.inspect_rbs(data)
+    bytes = data.to_s.b
+    return { format: :legacy, version: nil, payload_bytes: bytes.bytesize } unless container?(bytes)
+    raise FormatError, 'File is too small to contain a complete header' if bytes.bytesize < HEADER_SIZE
+
+    version, encrypted_length = bytes.byteslice(MAGIC.bytesize, 5).unpack('CL<')
+    {
+      format: :container,
+      version: version,
+      payload_bytes: encrypted_length,
+      total_bytes: bytes.bytesize
+    }
+  end
+
+  def self.validate_key!(key)
+    raise ArgumentError, 'Key is required' if key.nil? || key.empty?
+    key
+  end
+  private_class_method :validate_key!
+
+  def self.secure_compare(left, right)
+    return false unless left.bytesize == right.bytesize
+    left.bytes.zip(right.bytes).reduce(0) { |memo, (a, b)| memo | (a ^ b) }.zero?
+  end
+  private_class_method :secure_compare
 end

--- a/lib/rbshard/stream.rb
+++ b/lib/rbshard/stream.rb
@@ -1,0 +1,316 @@
+# frozen_string_literal: true
+
+require 'stringio'
+
+module RbShard
+  STREAM_FORMAT_VERSION = 3
+  V3_SALT_SIZE = 16
+  V3_HEADER_SIZE = 29
+  V3_CHUNK_MARKER = "CHNK".b.freeze
+  V3_FOOTER_MARKER = "END!".b.freeze
+  V3_RECORD_HEADER_SIZE = 32
+  V3_TAG_SIZE = 32
+  V3_FOOTER_SIZE = 48
+  V3_DEFAULT_CHUNK_SIZE = 1024 * 1024
+  V3_MIN_CHUNK_SIZE = 1024
+  V3_MAX_CHUNK_SIZE = 64 * 1024 * 1024
+
+  # Stream a file/IO into an authenticated RBS v3 container. Memory use is
+  # bounded by roughly one plaintext chunk, one compressed chunk, and one
+  # ciphertext chunk instead of the entire input file.
+  def self.pack_stream(input_io, output_io, key, chunk_size: V3_DEFAULT_CHUNK_SIZE, kdf_iterations: V2_KDF_ITERATIONS)
+    validate_password!(key)
+    validate_iterations!(kdf_iterations)
+    validate_chunk_size!(chunk_size)
+
+    salt = SecureRandom.random_bytes(V3_SALT_SIZE)
+    encryption_key, authentication_key = derive_v2_keys(key, salt, kdf_iterations)
+    header = MAGIC + [STREAM_FORMAT_VERSION, kdf_iterations, chunk_size].pack('CL<L<') + salt
+    output_io.write(header)
+
+    final_mac = OpenSSL::HMAC.new(authentication_key, OpenSSL::Digest.new('SHA256'))
+    final_mac.update(header)
+
+    chunk_index = 0
+    total_plaintext = 0
+
+    loop do
+      plaintext = input_io.read(chunk_size)
+      break if plaintext.nil? || plaintext.empty?
+
+      plaintext = plaintext.b
+      compressed = LZW.compress(plaintext)
+      iv = SecureRandom.random_bytes(V2_IV_SIZE)
+      ciphertext = encrypt_cbc(compressed, encryption_key, iv)
+      record_header = V3_CHUNK_MARKER +
+                      [chunk_index, plaintext.bytesize, ciphertext.bytesize].pack('L<L<L<') +
+                      iv
+      tag = OpenSSL::HMAC.digest('SHA256', authentication_key, header + record_header + ciphertext)
+
+      output_io.write(record_header)
+      output_io.write(ciphertext)
+      output_io.write(tag)
+      final_mac.update(tag)
+
+      total_plaintext += plaintext.bytesize
+      chunk_index += 1
+    end
+
+    footer_metadata = V3_FOOTER_MARKER + [chunk_index, total_plaintext].pack('L<Q<')
+    final_mac.update(footer_metadata)
+    output_io.write(footer_metadata)
+    output_io.write(final_mac.digest)
+
+    {
+      format: :container,
+      version: STREAM_FORMAT_VERSION,
+      streaming: true,
+      authenticated: true,
+      chunk_size: chunk_size,
+      chunk_count: chunk_index,
+      plaintext_bytes: total_plaintext,
+      kdf_iterations: kdf_iterations
+    }
+  end
+
+  # Verify and decrypt an RBS v3 stream. Each chunk is authenticated before it
+  # is decrypted and emitted. The final footer authenticates the ordered list
+  # of chunk tags plus aggregate counts, detecting truncation or reordering.
+  def self.unpack_stream(input_io, output_io, key)
+    validate_password!(key)
+    header = read_exact(input_io, V3_HEADER_SIZE, 'RBS v3 header')
+    raise FormatError, 'Invalid RbShard magic header' unless header.start_with?(MAGIC)
+
+    version, kdf_iterations, chunk_size = header.byteslice(4, 9).unpack('CL<L<')
+    raise FormatError, "Unsupported RbShard streaming format version: #{version}" unless version == STREAM_FORMAT_VERSION
+    validate_iterations!(kdf_iterations)
+    validate_chunk_size!(chunk_size)
+
+    salt = header.byteslice(13, V3_SALT_SIZE)
+    encryption_key, authentication_key = derive_v2_keys(key, salt, kdf_iterations)
+    final_mac = OpenSSL::HMAC.new(authentication_key, OpenSSL::Digest.new('SHA256'))
+    final_mac.update(header)
+
+    expected_index = 0
+    total_plaintext = 0
+
+    loop do
+      marker = read_exact(input_io, 4, 'RBS v3 record marker')
+
+      case marker
+      when V3_CHUNK_MARKER
+        remainder = read_exact(input_io, V3_RECORD_HEADER_SIZE - 4, 'RBS v3 chunk header')
+        record_header = marker + remainder
+        index, plaintext_length, ciphertext_length = remainder.byteslice(0, 12).unpack('L<L<L<')
+        iv = remainder.byteslice(12, V2_IV_SIZE)
+
+        raise FormatError, "Unexpected chunk index #{index}; expected #{expected_index}" unless index == expected_index
+        unless plaintext_length.positive? && plaintext_length <= chunk_size
+          raise FormatError, 'RBS v3 chunk plaintext length is outside the accepted range'
+        end
+
+        max_ciphertext = (plaintext_length * 2) + 16
+        unless ciphertext_length.positive? && ciphertext_length <= max_ciphertext
+          raise FormatError, 'RBS v3 chunk ciphertext length is outside the accepted range'
+        end
+
+        ciphertext = read_exact(input_io, ciphertext_length, 'RBS v3 chunk ciphertext')
+        expected_tag = read_exact(input_io, V3_TAG_SIZE, 'RBS v3 chunk authentication tag')
+        actual_tag = OpenSSL::HMAC.digest('SHA256', authentication_key, header + record_header + ciphertext)
+        raise IntegrityError, 'Chunk authentication failed; the key may be wrong or the file may be corrupted' unless secure_compare(actual_tag, expected_tag)
+
+        compressed = decrypt_cbc(ciphertext, encryption_key, iv)
+        plaintext = LZW.decompress(compressed)
+        raise IntegrityError, 'Authenticated chunk plaintext length does not match its record' unless plaintext.bytesize == plaintext_length
+
+        output_io.write(plaintext)
+        final_mac.update(expected_tag)
+        total_plaintext += plaintext_length
+        expected_index += 1
+      when V3_FOOTER_MARKER
+        footer_remainder = read_exact(input_io, V3_FOOTER_SIZE - 4, 'RBS v3 footer')
+        chunk_count, declared_plaintext = footer_remainder.byteslice(0, 12).unpack('L<Q<')
+        expected_final_tag = footer_remainder.byteslice(12, V3_TAG_SIZE)
+        footer_metadata = marker + footer_remainder.byteslice(0, 12)
+
+        raise FormatError, 'RBS v3 footer chunk count does not match decoded records' unless chunk_count == expected_index
+        raise FormatError, 'RBS v3 footer plaintext length does not match decoded records' unless declared_plaintext == total_plaintext
+
+        final_mac.update(footer_metadata)
+        actual_final_tag = final_mac.digest
+        raise IntegrityError, 'Final stream authentication failed; the archive may be truncated or reordered' unless secure_compare(actual_final_tag, expected_final_tag)
+        raise FormatError, 'Trailing data found after RBS v3 footer' unless input_io.read(1).nil?
+
+        return {
+          format: :container,
+          version: STREAM_FORMAT_VERSION,
+          streaming: true,
+          authenticated: true,
+          chunk_size: chunk_size,
+          chunk_count: chunk_count,
+          plaintext_bytes: declared_plaintext,
+          kdf_iterations: kdf_iterations
+        }
+      else
+        raise FormatError, "Invalid RBS v3 record marker: #{marker.inspect}"
+      end
+    end
+  rescue IntegrityError, FormatError
+    raise
+  rescue StandardError => e
+    raise IntegrityError, "Unable to decode RbShard v3 stream: #{e.message}"
+  end
+
+  def self.pack_file(input_path, output_path, key, chunk_size: V3_DEFAULT_CHUNK_SIZE, kdf_iterations: V2_KDF_ITERATIONS)
+    File.open(input_path, 'rb') do |input|
+      File.open(output_path, 'wb') do |output|
+        pack_stream(input, output, key, chunk_size: chunk_size, kdf_iterations: kdf_iterations)
+      end
+    end
+  end
+
+  # File-oriented unpacking commits plaintext atomically. A failed footer/tag
+  # never leaves a partially verified destination file behind.
+  def self.unpack_file(input_path, output_path, key, allow_legacy: true)
+    File.open(input_path, 'rb') do |input|
+      prefix = input.read(5)
+      input.rewind
+
+      if prefix&.start_with?(MAGIC) && prefix.getbyte(4) == STREAM_FORMAT_VERSION
+        atomic_output(output_path) do |output|
+          unpack_stream(input, output, key)
+        end
+      else
+        plaintext = load_rbs(input_path, key, allow_legacy: allow_legacy)
+        atomic_output(output_path) { |output| output.write(plaintext) }
+      end
+    end
+  end
+
+  def self.inspect_rbs_file(path)
+    total_bytes = File.size(path)
+    File.open(path, 'rb') do |io|
+      prefix = io.read(5)
+      return { format: :legacy, version: nil, payload_bytes: total_bytes, total_bytes: total_bytes } unless prefix&.start_with?(MAGIC)
+
+      version = prefix.getbyte(4)
+      io.rewind
+      case version
+      when 1
+        header = read_exact(io, V1_HEADER_SIZE, 'RBS v1 header')
+        encrypted_length = header.byteslice(5, 4).unpack1('L<')
+        {
+          format: :container, version: 1, authenticated: false,
+          payload_bytes: encrypted_length, total_bytes: total_bytes
+        }
+      when 2
+        header = read_exact(io, V2_HEADER_SIZE, 'RBS v2 header')
+        _version, kdf_iterations = header.byteslice(4, 5).unpack('CL<')
+        encrypted_length = header.byteslice(41, 4).unpack1('L<')
+        {
+          format: :container, version: 2, streaming: false, authenticated: true,
+          kdf: :'pbkdf2-hmac-sha256', kdf_iterations: kdf_iterations,
+          cipher: :'twofish-cbc', payload_bytes: encrypted_length, total_bytes: total_bytes
+        }
+      when STREAM_FORMAT_VERSION
+        header = read_exact(io, V3_HEADER_SIZE, 'RBS v3 header')
+        _version, kdf_iterations, chunk_size = header.byteslice(4, 9).unpack('CL<L<')
+        validate_iterations!(kdf_iterations)
+        validate_chunk_size!(chunk_size)
+
+        metadata = {
+          format: :container, version: STREAM_FORMAT_VERSION, streaming: true,
+          authenticated: true, kdf: :'pbkdf2-hmac-sha256',
+          kdf_iterations: kdf_iterations, cipher: :'twofish-cbc',
+          chunk_size: chunk_size, total_bytes: total_bytes
+        }
+
+        if total_bytes >= V3_HEADER_SIZE + V3_FOOTER_SIZE
+          io.seek(-V3_FOOTER_SIZE, IO::SEEK_END)
+          footer = io.read(V3_FOOTER_SIZE)
+          if footer&.start_with?(V3_FOOTER_MARKER)
+            chunk_count, plaintext_bytes = footer.byteslice(4, 12).unpack('L<Q<')
+            metadata[:chunk_count] = chunk_count
+            metadata[:plaintext_bytes] = plaintext_bytes
+          end
+        end
+        metadata
+      else
+        { format: :container, version: version, supported: false, total_bytes: total_bytes }
+      end
+    end
+  end
+
+  def self.unpack_v3_bytes(bytes, key)
+    input = StringIO.new(bytes.to_s.b)
+    output = StringIO.new(''.b)
+    unpack_stream(input, output, key)
+    output.string
+  end
+  private_class_method :unpack_v3_bytes
+
+  def self.inspect_v3_bytes(bytes)
+    input = StringIO.new(bytes.to_s.b)
+    header = read_exact(input, V3_HEADER_SIZE, 'RBS v3 header')
+    _version, kdf_iterations, chunk_size = header.byteslice(4, 9).unpack('CL<L<')
+    validate_iterations!(kdf_iterations)
+    validate_chunk_size!(chunk_size)
+
+    metadata = {
+      format: :container, version: STREAM_FORMAT_VERSION, streaming: true,
+      authenticated: true, kdf: :'pbkdf2-hmac-sha256',
+      kdf_iterations: kdf_iterations, cipher: :'twofish-cbc',
+      chunk_size: chunk_size, total_bytes: bytes.bytesize
+    }
+
+    if bytes.bytesize >= V3_HEADER_SIZE + V3_FOOTER_SIZE
+      footer = bytes.byteslice(bytes.bytesize - V3_FOOTER_SIZE, V3_FOOTER_SIZE)
+      if footer.start_with?(V3_FOOTER_MARKER)
+        chunk_count, plaintext_bytes = footer.byteslice(4, 12).unpack('L<Q<')
+        metadata[:chunk_count] = chunk_count
+        metadata[:plaintext_bytes] = plaintext_bytes
+      end
+    end
+    metadata
+  end
+  private_class_method :inspect_v3_bytes
+
+  def self.validate_chunk_size!(chunk_size)
+    unless chunk_size.is_a?(Integer) && chunk_size.between?(V3_MIN_CHUNK_SIZE, V3_MAX_CHUNK_SIZE)
+      raise FormatError, "Chunk size must be between #{V3_MIN_CHUNK_SIZE} and #{V3_MAX_CHUNK_SIZE} bytes"
+    end
+    chunk_size
+  end
+  private_class_method :validate_chunk_size!
+
+  def self.read_exact(io, length, label)
+    data = ''.b
+    while data.bytesize < length
+      part = io.read(length - data.bytesize)
+      raise FormatError, "Truncated #{label}" if part.nil? || part.empty?
+      data << part.b
+    end
+    data
+  end
+  private_class_method :read_exact
+
+  def self.atomic_output(path)
+    directory = File.dirname(File.expand_path(path))
+    basename = File.basename(path)
+    temporary = File.join(directory, ".#{basename}.rbshard-#{Process.pid}-#{SecureRandom.hex(6)}.tmp")
+
+    begin
+      result = nil
+      File.open(temporary, 'wb', 0o600) do |output|
+        result = yield output
+        output.flush
+        output.fsync rescue nil
+      end
+      File.rename(temporary, path)
+      result
+    ensure
+      File.delete(temporary) if File.exist?(temporary)
+    end
+  end
+  private_class_method :atomic_output
+end

--- a/rbshard.gemspec
+++ b/rbshard.gemspec
@@ -1,14 +1,31 @@
 require_relative 'lib/rbshard/version'
+
 Gem::Specification.new do |spec|
   spec.name          = 'rbshard'
   spec.version       = RbShard::VERSION
-  spec.authors       = ['Unknown']
-  spec.email         = ['unknown@example.com']
-  spec.summary       = 'Compression and encryption toolkit'
-  spec.files         = Dir['lib/**/*'] + ['README.md', 'LICENSE', 'bin/rbshard_desktop', 'bin/rbshard_ui']
+  spec.authors       = ['djlacavera21']
+  spec.summary       = 'Binary-safe compression and encrypted RBS container toolkit'
+  spec.description   = 'RbShard provides LZW compression, Twofish encryption, versioned .rbs containers, file helpers, and a command-line interface.'
+  spec.homepage      = 'https://github.com/djlacavera21/rbshard'
+  spec.license       = 'MIT'
+  spec.required_ruby_version = '>= 3.0'
+
+  spec.metadata = {
+    'source_code_uri' => spec.homepage,
+    'changelog_uri' => "#{spec.homepage}/blob/main/CHANGELOG.md"
+  }
+
+  spec.files = Dir['lib/**/*', 'docs/**/*', 'bin/*'] + ['README.md', 'LICENSE', 'CHANGELOG.md']
+  spec.bindir        = 'bin'
+  spec.executables   = ['rbshard']
   spec.require_paths = ['lib']
+
   spec.add_runtime_dependency 'twofish', '~> 1.0'
-  spec.add_runtime_dependency 'gtk3', '>= 4.0'
+  spec.add_runtime_dependency 'webrick', '>= 1.8'
+
+  # GTK is only required for bin/rbshard_desktop. Keeping it as a development
+  # dependency prevents headless/core gem users from pulling the native UI stack.
+  spec.add_development_dependency 'gtk3', '>= 4.0'
   spec.add_development_dependency 'minitest', '~> 5'
   spec.add_development_dependency 'rake', '~> 13'
 end

--- a/rbshard.gemspec
+++ b/rbshard.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.version       = RbShard::VERSION
   spec.authors       = ['djlacavera21']
   spec.summary       = 'Binary-safe compression and encrypted RBS container toolkit'
-  spec.description   = 'RbShard provides LZW compression, Twofish encryption, versioned .rbs containers, file helpers, and a command-line interface.'
+  spec.description   = 'RbShard provides LZW compression, authenticated versioned .rbs containers, streaming large-file workflows, file helpers, and a command-line interface.'
   spec.homepage      = 'https://github.com/djlacavera21/rbshard'
   spec.license       = 'MIT'
   spec.required_ruby_version = '>= 3.0'
@@ -15,13 +15,13 @@ Gem::Specification.new do |spec|
     'changelog_uri' => "#{spec.homepage}/blob/main/CHANGELOG.md"
   }
 
-  spec.files = Dir['lib/**/*', 'docs/**/*', 'bin/*'] + ['README.md', 'LICENSE', 'CHANGELOG.md']
+  spec.files = Dir['lib/**/*', 'docs/**/*', 'bin/*'] + ['README.md', 'LICENSE', 'CHANGELOG.md', 'SECURITY.md']
   spec.bindir        = 'bin'
   spec.executables   = ['rbshard']
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'twofish', '~> 1.0'
-  spec.add_runtime_dependency 'webrick', '>= 1.8'
+  spec.add_runtime_dependency 'webrick', '~> 1.8'
 
   spec.add_development_dependency 'minitest', '~> 5'
   spec.add_development_dependency 'rake', '~> 13'

--- a/rbshard.gemspec
+++ b/rbshard.gemspec
@@ -23,9 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'twofish', '~> 1.0'
   spec.add_runtime_dependency 'webrick', '>= 1.8'
 
-  # GTK is only required for bin/rbshard_desktop. Keeping it as a development
-  # dependency prevents headless/core gem users from pulling the native UI stack.
-  spec.add_development_dependency 'gtk3', '>= 4.0'
   spec.add_development_dependency 'minitest', '~> 5'
   spec.add_development_dependency 'rake', '~> 13'
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -23,25 +23,33 @@ class RbShardCLITest < Minitest::Test
       input = File.join(dir, 'input.bin')
       archive = File.join(dir, 'archive.rbs')
       output = File.join(dir, 'output.bin')
-      original = "hello\x00rbshard\xff".b
+      original = ("hello\x00rbshard\xff".b * 300)
       File.binwrite(input, original)
 
-      _stdout, stderr, status = run_cli(
-        'pack', '--kdf-iterations', '10000', '--key-env', 'RBSHARD_TEST_KEY', input, archive,
+      stdout, stderr, status = run_cli(
+        'pack', '--kdf-iterations', '10000', '--chunk-size', '1024',
+        '--key-env', 'RBSHARD_TEST_KEY', input, archive,
         env: { 'RBSHARD_TEST_KEY' => KEY }
       )
       assert status.success?, stderr
+      assert_includes stdout, '(v3,'
       assert File.exist?(archive)
 
       stdout, stderr, status = run_cli('inspect', archive)
       assert status.success?, stderr
       assert_includes stdout, 'format: container'
-      assert_includes stdout, 'version: 2'
+      assert_includes stdout, 'version: 3'
+      assert_includes stdout, 'streaming: true'
       assert_includes stdout, 'authenticated: true'
       assert_includes stdout, 'kdf_iterations: 10000'
+      assert_includes stdout, 'chunk_size: 1024'
 
-      _stdout, stderr, status = run_cli('unpack', '--key-env', 'RBSHARD_TEST_KEY', archive, output, env: { 'RBSHARD_TEST_KEY' => KEY })
+      stdout, stderr, status = run_cli(
+        'unpack', '--key-env', 'RBSHARD_TEST_KEY', archive, output,
+        env: { 'RBSHARD_TEST_KEY' => KEY }
+      )
       assert status.success?, stderr
+      assert_includes stdout, '(v3)'
       assert_equal original, File.binread(output)
     end
   end
@@ -71,6 +79,20 @@ class RbShardCLITest < Minitest::Test
       _stdout, stderr, status = run_cli('unpack', '--no-legacy', '--key', KEY, legacy, output)
       refute status.success?
       assert_includes stderr, 'Legacy headerless RbShard payload rejected'
+    end
+  end
+
+  def test_invalid_chunk_size_is_reported
+    Dir.mktmpdir('rbshard-cli') do |dir|
+      input = File.join(dir, 'input.txt')
+      archive = File.join(dir, 'archive.rbs')
+      File.write(input, 'data')
+
+      _stdout, stderr, status = run_cli(
+        'pack', '--chunk-size', '32', '--key', KEY, input, archive
+      )
+      refute status.success?
+      assert_includes stderr, 'Chunk size must be between'
     end
   end
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -26,14 +26,19 @@ class RbShardCLITest < Minitest::Test
       original = "hello\x00rbshard\xff".b
       File.binwrite(input, original)
 
-      _stdout, stderr, status = run_cli('pack', '--key-env', 'RBSHARD_TEST_KEY', input, archive, env: { 'RBSHARD_TEST_KEY' => KEY })
+      _stdout, stderr, status = run_cli(
+        'pack', '--kdf-iterations', '10000', '--key-env', 'RBSHARD_TEST_KEY', input, archive,
+        env: { 'RBSHARD_TEST_KEY' => KEY }
+      )
       assert status.success?, stderr
       assert File.exist?(archive)
 
       stdout, stderr, status = run_cli('inspect', archive)
       assert status.success?, stderr
       assert_includes stdout, 'format: container'
-      assert_includes stdout, 'version: 1'
+      assert_includes stdout, 'version: 2'
+      assert_includes stdout, 'authenticated: true'
+      assert_includes stdout, 'kdf_iterations: 10000'
 
       _stdout, stderr, status = run_cli('unpack', '--key-env', 'RBSHARD_TEST_KEY', archive, output, env: { 'RBSHARD_TEST_KEY' => KEY })
       assert status.success?, stderr

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -1,0 +1,71 @@
+require 'minitest/autorun'
+require 'open3'
+require 'rbconfig'
+require 'tmpdir'
+
+class RbShardCLITest < Minitest::Test
+  ROOT = File.expand_path('..', __dir__)
+  CLI = File.join(ROOT, 'bin', 'rbshard')
+  KEY = 'secretkey1234567'.freeze
+
+  def run_cli(*args, env: {})
+    Open3.capture3(env, RbConfig.ruby, CLI, *args, chdir: ROOT)
+  end
+
+  def test_version
+    stdout, stderr, status = run_cli('version')
+    assert status.success?, stderr
+    assert_match(/\A\d+\.\d+\.\d+/, stdout)
+  end
+
+  def test_pack_inspect_and_unpack_round_trip
+    Dir.mktmpdir('rbshard-cli') do |dir|
+      input = File.join(dir, 'input.bin')
+      archive = File.join(dir, 'archive.rbs')
+      output = File.join(dir, 'output.bin')
+      original = "hello\x00rbshard\xff".b
+      File.binwrite(input, original)
+
+      _stdout, stderr, status = run_cli('pack', '--key-env', 'RBSHARD_TEST_KEY', input, archive, env: { 'RBSHARD_TEST_KEY' => KEY })
+      assert status.success?, stderr
+      assert File.exist?(archive)
+
+      stdout, stderr, status = run_cli('inspect', archive)
+      assert status.success?, stderr
+      assert_includes stdout, 'format: container'
+      assert_includes stdout, 'version: 1'
+
+      _stdout, stderr, status = run_cli('unpack', '--key-env', 'RBSHARD_TEST_KEY', archive, output, env: { 'RBSHARD_TEST_KEY' => KEY })
+      assert status.success?, stderr
+      assert_equal original, File.binread(output)
+    end
+  end
+
+  def test_missing_key_is_reported
+    Dir.mktmpdir('rbshard-cli') do |dir|
+      input = File.join(dir, 'input.txt')
+      output = File.join(dir, 'output.rbs')
+      File.write(input, 'data')
+
+      _stdout, stderr, status = run_cli('pack', input, output)
+      refute status.success?
+      assert_includes stderr, 'provide exactly one of --key, --key-env, or --key-file'
+    end
+  end
+
+  def test_unpack_can_reject_legacy_payload
+    Dir.mktmpdir('rbshard-cli') do |dir|
+      input = File.join(dir, 'plain.txt')
+      legacy = File.join(dir, 'legacy.rbs')
+      output = File.join(dir, 'output.txt')
+      File.write(input, 'legacy')
+
+      _stdout, stderr, status = run_cli('encode', '--key', KEY, input, legacy)
+      assert status.success?, stderr
+
+      _stdout, stderr, status = run_cli('unpack', '--no-legacy', '--key', KEY, legacy, output)
+      refute status.success?
+      assert_includes stderr, 'Legacy headerless RbShard payload rejected'
+    end
+  end
+end

--- a/test/test_rbshard.rb
+++ b/test/test_rbshard.rb
@@ -1,17 +1,19 @@
+require 'digest'
 require 'minitest/autorun'
 require 'tempfile'
 require_relative '../lib/rbshard'
 
 class RbShardTest < Minitest::Test
   KEY = 'secretkey1234567'.freeze
+  FAST_KDF_ITERATIONS = 10_000
 
-  def test_round_trip
+  def test_legacy_round_trip
     data = 'Hello rbshard!'
     encoded = RbShard.encode(data, KEY)
     assert_equal data, RbShard.decode(encoded, KEY)
   end
 
-  def test_binary_round_trip
+  def test_legacy_binary_round_trip
     data = (0..255).to_a.pack('C*') * 4
     assert_equal data, RbShard.decode(RbShard.encode(data, KEY), KEY)
   end
@@ -20,36 +22,77 @@ class RbShardTest < Minitest::Test
     assert_equal ''.b, RbShard::LZW.decompress(RbShard::LZW.compress(''))
   end
 
-  def test_versioned_container_round_trip
+  def test_v2_container_round_trip
     data = "container data\x00with binary".b
-    packed = RbShard.pack(data, KEY)
+    packed = RbShard.pack(data, KEY, kdf_iterations: FAST_KDF_ITERATIONS)
+    metadata = RbShard.inspect_rbs(packed)
 
     assert RbShard.container?(packed)
     assert_equal data, RbShard.unpack(packed, KEY)
-    assert_equal :container, RbShard.inspect_rbs(packed)[:format]
-    assert_equal RbShard::FORMAT_VERSION, RbShard.inspect_rbs(packed)[:version]
+    assert_equal :container, metadata[:format]
+    assert_equal 2, metadata[:version]
+    assert_equal true, metadata[:authenticated]
+    assert_equal :'pbkdf2-hmac-sha256', metadata[:kdf]
+    assert_equal FAST_KDF_ITERATIONS, metadata[:kdf_iterations]
+    assert_equal :'twofish-cbc', metadata[:cipher]
   end
 
-  def test_container_detects_corruption
-    packed = RbShard.pack('important data', KEY).dup
+  def test_v2_uses_random_salt_and_iv
+    first = RbShard.pack('same data', KEY, kdf_iterations: FAST_KDF_ITERATIONS)
+    second = RbShard.pack('same data', KEY, kdf_iterations: FAST_KDF_ITERATIONS)
+
+    refute_equal first, second
+    assert_equal 'same data', RbShard.unpack(first, KEY)
+    assert_equal 'same data', RbShard.unpack(second, KEY)
+  end
+
+  def test_v2_detects_ciphertext_corruption_before_decryption
+    packed = RbShard.pack('important data', KEY, kdf_iterations: FAST_KDF_ITERATIONS).dup
+    payload_offset = RbShard::V2_HEADER_SIZE
+    packed.setbyte(payload_offset, packed.getbyte(payload_offset) ^ 0xff)
+
+    assert_raises(RbShard::IntegrityError) { RbShard.unpack(packed, KEY) }
+  end
+
+  def test_v2_detects_tag_corruption
+    packed = RbShard.pack('important data', KEY, kdf_iterations: FAST_KDF_ITERATIONS).dup
     packed.setbyte(packed.bytesize - 1, packed.getbyte(packed.bytesize - 1) ^ 0xff)
 
     assert_raises(RbShard::IntegrityError) { RbShard.unpack(packed, KEY) }
   end
 
+  def test_v2_rejects_wrong_key
+    packed = RbShard.pack('important data', KEY, kdf_iterations: FAST_KDF_ITERATIONS)
+
+    assert_raises(RbShard::IntegrityError) do
+      RbShard.unpack(packed, 'different-password')
+    end
+  end
+
   def test_container_rejects_bad_magic
-    packed = RbShard.pack('data', KEY).dup
+    packed = RbShard.pack('data', KEY, kdf_iterations: FAST_KDF_ITERATIONS).dup
     packed[0, 4] = 'NOPE'
 
     assert_raises(RbShard::FormatError) { RbShard.unpack(packed, KEY) }
   end
 
-  def test_save_and_load_rbs_uses_container_format
+  def test_unpack_reads_v1_container
+    plaintext = 'v1 compatibility'
+    encrypted = RbShard.encode(plaintext, KEY)
+    v1 = RbShard::MAGIC + [1, encrypted.bytesize].pack('CL<') + encrypted + Digest::SHA256.digest(plaintext)
+
+    assert_equal plaintext, RbShard.unpack(v1, KEY)
+    assert_equal 1, RbShard.inspect_rbs(v1)[:version]
+    assert_equal false, RbShard.inspect_rbs(v1)[:authenticated]
+  end
+
+  def test_save_and_load_rbs_uses_current_container_format
     Tempfile.create(['rbshard', '.rbs']) do |file|
-      RbShard.save_rbs(file.path, 'saved data', KEY)
+      RbShard.save_rbs(file.path, 'saved data', KEY, kdf_iterations: FAST_KDF_ITERATIONS)
       raw = File.binread(file.path)
 
       assert RbShard.container?(raw)
+      assert_equal 2, RbShard.inspect_rbs(raw)[:version]
       assert_equal 'saved data', RbShard.load_rbs(file.path, KEY)
     end
   end
@@ -61,6 +104,16 @@ class RbShardTest < Minitest::Test
       assert_raises(RbShard::FormatError) do
         RbShard.load_rbs(file.path, KEY, allow_legacy: false)
       end
+    end
+  end
+
+  def test_legacy_key_length_is_bounded
+    assert_raises(ArgumentError) { RbShard.encode('data', 'x' * 33) }
+  end
+
+  def test_v2_rejects_unreasonable_kdf_iterations
+    assert_raises(RbShard::FormatError) do
+      RbShard.pack('data', KEY, kdf_iterations: 999)
     end
   end
 end

--- a/test/test_rbshard.rb
+++ b/test/test_rbshard.rb
@@ -1,12 +1,66 @@
 require 'minitest/autorun'
+require 'tempfile'
 require_relative '../lib/rbshard'
 
 class RbShardTest < Minitest::Test
+  KEY = 'secretkey1234567'.freeze
+
   def test_round_trip
     data = 'Hello rbshard!'
-    key = 'secretkey1234567'
-    encoded = RbShard.encode(data, key)
-    decoded = RbShard.decode(encoded, key)
-    assert_equal data, decoded
+    encoded = RbShard.encode(data, KEY)
+    assert_equal data, RbShard.decode(encoded, KEY)
+  end
+
+  def test_binary_round_trip
+    data = (0..255).to_a.pack('C*') * 4
+    assert_equal data, RbShard.decode(RbShard.encode(data, KEY), KEY)
+  end
+
+  def test_empty_lzw_round_trip
+    assert_equal ''.b, RbShard::LZW.decompress(RbShard::LZW.compress(''))
+  end
+
+  def test_versioned_container_round_trip
+    data = "container data\x00with binary".b
+    packed = RbShard.pack(data, KEY)
+
+    assert RbShard.container?(packed)
+    assert_equal data, RbShard.unpack(packed, KEY)
+    assert_equal :container, RbShard.inspect_rbs(packed)[:format]
+    assert_equal RbShard::FORMAT_VERSION, RbShard.inspect_rbs(packed)[:version]
+  end
+
+  def test_container_detects_corruption
+    packed = RbShard.pack('important data', KEY).dup
+    packed.setbyte(packed.bytesize - 1, packed.getbyte(packed.bytesize - 1) ^ 0xff)
+
+    assert_raises(RbShard::IntegrityError) { RbShard.unpack(packed, KEY) }
+  end
+
+  def test_container_rejects_bad_magic
+    packed = RbShard.pack('data', KEY).dup
+    packed[0, 4] = 'NOPE'
+
+    assert_raises(RbShard::FormatError) { RbShard.unpack(packed, KEY) }
+  end
+
+  def test_save_and_load_rbs_uses_container_format
+    Tempfile.create(['rbshard', '.rbs']) do |file|
+      RbShard.save_rbs(file.path, 'saved data', KEY)
+      raw = File.binread(file.path)
+
+      assert RbShard.container?(raw)
+      assert_equal 'saved data', RbShard.load_rbs(file.path, KEY)
+    end
+  end
+
+  def test_load_rbs_supports_legacy_payloads
+    Tempfile.create(['rbshard-legacy', '.rbs']) do |file|
+      File.binwrite(file.path, RbShard.encode('legacy data', KEY))
+      assert_equal 'legacy data', RbShard.load_rbs(file.path, KEY)
+      assert_raises(RbShard::FormatError) do
+        RbShard.load_rbs(file.path, KEY, allow_legacy: false)
+      end
+    end
   end
 end

--- a/test/test_stream.rb
+++ b/test/test_stream.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'stringio'
+require 'tmpdir'
+require_relative '../lib/rbshard'
+
+class RbShardStreamTest < Minitest::Test
+  KEY = 'streaming-test-password'.freeze
+  FAST_KDF_ITERATIONS = 10_000
+  CHUNK_SIZE = 1024
+
+  def stream_pack(data)
+    input = StringIO.new(data.b)
+    output = StringIO.new(''.b)
+    metadata = RbShard.pack_stream(
+      input,
+      output,
+      KEY,
+      chunk_size: CHUNK_SIZE,
+      kdf_iterations: FAST_KDF_ITERATIONS
+    )
+    [output.string, metadata]
+  end
+
+  def test_multi_chunk_stream_round_trip
+    original = ((0..255).to_a.pack('C*') * 13) + 'tail'
+    archive, packed_metadata = stream_pack(original)
+    restored = StringIO.new(''.b)
+    unpacked_metadata = RbShard.unpack_stream(StringIO.new(archive), restored, KEY)
+
+    assert_equal original.b, restored.string
+    assert_equal 3, packed_metadata[:version]
+    assert_equal 4, packed_metadata[:chunk_count]
+    assert_equal packed_metadata[:chunk_count], unpacked_metadata[:chunk_count]
+    assert_equal original.bytesize, unpacked_metadata[:plaintext_bytes]
+  end
+
+  def test_empty_stream_round_trip
+    archive, metadata = stream_pack('')
+    restored = StringIO.new(''.b)
+    result = RbShard.unpack_stream(StringIO.new(archive), restored, KEY)
+
+    assert_equal ''.b, restored.string
+    assert_equal 0, metadata[:chunk_count]
+    assert_equal 0, result[:plaintext_bytes]
+  end
+
+  def test_in_memory_unpack_accepts_v3
+    original = 'v3 through generic unpack' * 100
+    archive, = stream_pack(original)
+
+    assert_equal original, RbShard.unpack(archive, KEY)
+    metadata = RbShard.inspect_rbs(archive)
+    assert_equal 3, metadata[:version]
+    assert_equal true, metadata[:streaming]
+  end
+
+  def test_chunk_tampering_is_rejected
+    archive, = stream_pack('A' * 3000)
+    corrupted = archive.dup
+    ciphertext_offset = RbShard::V3_HEADER_SIZE + RbShard::V3_RECORD_HEADER_SIZE
+    corrupted.setbyte(ciphertext_offset, corrupted.getbyte(ciphertext_offset) ^ 0xff)
+
+    assert_raises(RbShard::IntegrityError) do
+      RbShard.unpack_stream(StringIO.new(corrupted), StringIO.new(''.b), KEY)
+    end
+  end
+
+  def test_truncated_footer_is_rejected
+    archive, = stream_pack('footer check' * 200)
+    truncated = archive.byteslice(0, archive.bytesize - 10)
+
+    assert_raises(RbShard::FormatError) do
+      RbShard.unpack_stream(StringIO.new(truncated), StringIO.new(''.b), KEY)
+    end
+  end
+
+  def test_file_unpack_is_atomic_on_authentication_failure
+    Dir.mktmpdir('rbshard-stream') do |dir|
+      input = File.join(dir, 'input.bin')
+      archive = File.join(dir, 'archive.rbs')
+      output = File.join(dir, 'output.bin')
+      original = SecureRandom.random_bytes(5000)
+      File.binwrite(input, original)
+      File.binwrite(output, 'existing destination')
+
+      RbShard.pack_file(
+        input,
+        archive,
+        KEY,
+        chunk_size: CHUNK_SIZE,
+        kdf_iterations: FAST_KDF_ITERATIONS
+      )
+
+      assert_raises(RbShard::IntegrityError) do
+        RbShard.unpack_file(archive, output, 'wrong-password')
+      end
+      assert_equal 'existing destination', File.binread(output)
+
+      metadata = RbShard.unpack_file(archive, output, KEY)
+      assert_equal original, File.binread(output)
+      assert_equal 3, metadata[:version]
+    end
+  end
+
+  def test_file_inspection_reads_v3_metadata_without_decryption
+    Dir.mktmpdir('rbshard-inspect') do |dir|
+      input = File.join(dir, 'input.bin')
+      archive = File.join(dir, 'archive.rbs')
+      original = 'metadata' * 1000
+      File.binwrite(input, original)
+
+      RbShard.pack_file(
+        input,
+        archive,
+        KEY,
+        chunk_size: CHUNK_SIZE,
+        kdf_iterations: FAST_KDF_ITERATIONS
+      )
+      metadata = RbShard.inspect_rbs_file(archive)
+
+      assert_equal 3, metadata[:version]
+      assert_equal true, metadata[:streaming]
+      assert_equal CHUNK_SIZE, metadata[:chunk_size]
+      assert_equal original.bytesize, metadata[:plaintext_bytes]
+      assert_operator metadata[:chunk_count], :>, 1
+    end
+  end
+end


### PR DESCRIPTION
## What changed

This PR expands RbShard from a minimal raw LZW + Twofish codec into a versioned encrypted-container toolkit with bounded-memory streaming file support while preserving backward compatibility.

### RBS v3 streaming file format

- adds self-identifying streaming `RBSH` format version 3
- splits plaintext into independently compressed/encrypted/authenticated chunk records
- derives independent encryption/authentication keys with PBKDF2-HMAC-SHA256 and a random file salt
- uses fresh random IVs for each Twofish-CBC chunk
- authenticates every chunk before decryption/decompression
- adds an authenticated final footer binding chunk order, chunk count, and total plaintext bytes
- detects truncation, reordering, invalid lengths, and trailing data
- uses a 1 MiB default chunk size with bounded accepted limits

### Large-file API

- adds `RbShard.pack_stream` / `RbShard.unpack_stream` for IO-to-IO bounded-memory processing
- adds `RbShard.pack_file` / `RbShard.unpack_file` for file workflows
- `unpack_file` writes to a temporary destination and atomically commits only after complete v3 authentication succeeds
- adds `inspect_rbs_file` so metadata inspection does not require loading entire archives
- generic `RbShard.unpack` and `inspect_rbs` also understand materialized v3 containers

### RBS v2 + compatibility

- retains authenticated v2 for the existing in-memory `pack` / `save_rbs` API
- retains reads for RBS v1
- preserves original headerless `encode` / `decode` compatibility
- supports `allow_legacy: false` / CLI `--no-legacy`

### Codec robustness

- makes LZW binary-safe and empty-input safe
- explicitly serializes codes little-endian
- bounds the LZW dictionary to 16-bit codes
- introduces structured `FormatError` and `IntegrityError` failures

### CLI and interfaces

- adds first-class `rbshard` executable
- CLI `pack` now streams directly to v3 instead of `File.binread`-ing the source
- CLI `unpack` streams/atomically commits v3 output while retaining v2/v1/legacy reads
- CLI `inspect` reads bounded metadata
- supports `--chunk-size`, `--kdf-iterations`, `--key`, `--key-env`, and `--key-file`
- keeps GTK optional and the web interface loopback-bound by default

### Tests and CI

- adds core, streaming, integrity, atomic-output, and CLI integration tests
- tests multi-chunk round trips, empty archives, chunk tampering, footer truncation, wrong-key behavior, and destination preservation
- modernizes Ruby compatibility checks to 3.0–3.4
- fixes the lockfile Bundler version so Ruby 3.0 can install dependencies
- replaces PR-time gem publishing with build-on-PR / publish-only-on-release behavior

### Documentation

- expands `README.md`
- adds/updates `docs/FORMAT.md`, `SECURITY.md`, and `CHANGELOG.md`
- documents the complete v3 record/footer layout and compatibility matrix

## Why

The original repository buffered complete payloads and had no format-evolution or authenticated-storage model. RBS v2 addressed authenticated in-memory containers; v3 extends that architecture to large files without requiring multi-gigabyte plaintext/ciphertext buffers.

The chunked design authenticates each record before plaintext release and authenticates the complete sequence at the footer. File-oriented decryption additionally uses atomic destination replacement so a failed final check cannot leave a partially verified target file behind.

## Security boundary

RBS v2/v3 are materially stronger than the legacy formats, but RbShard remains experimental and has not received an independent cryptographic audit. High-value or regulated secrets should still use a mature audited storage format/library. V1 and headerless payloads remain compatibility-only formats.

## Validation

The v3 implementation has passed the full test/smoke workflow on Ruby 3.1, 3.2, 3.3, and 3.4. The only observed Ruby 3.0 failure occurred before tests because the lockfile requested Bundler 2.6.7 (Ruby >=3.1); the lockfile has now been adjusted to Bundler 2.4.22 for Ruby 3.0 compatibility. Fresh Actions runs will validate that final toolchain adjustment.